### PR TITLE
Fix two code bugs

### DIFF
--- a/src/player-stats/repositories/player-league-stats.repository.ts
+++ b/src/player-stats/repositories/player-league-stats.repository.ts
@@ -26,6 +26,71 @@ export class PlayerLeagueStatsRepository {
     });
   }
 
+  async incrementStats(playerId: string, leagueId: string, data: {
+    matchesPlayed?: number;
+    wins?: number;
+    losses?: number;
+    draws?: number;
+    totalGoals?: number;
+    totalAssists?: number;
+    totalSaves?: number;
+    totalShots?: number;
+  }, tx?: Prisma.TransactionClient) {
+    const client = tx || this.prisma;
+    
+    // First upsert using atomic increments for counters
+    const updated = await client.playerLeagueStats.upsert({
+      where: { playerId_leagueId: { playerId, leagueId } },
+      create: {
+        playerId,
+        leagueId,
+        matchesPlayed: data.matchesPlayed || 0,
+        wins: data.wins || 0,
+        losses: data.losses || 0,
+        draws: data.draws || 0,
+        totalGoals: data.totalGoals || 0,
+        totalAssists: data.totalAssists || 0,
+        totalSaves: data.totalSaves || 0,
+        totalShots: data.totalShots || 0,
+        winRate: (data.matchesPlayed && data.matchesPlayed > 0 && data.wins) ? Number((data.wins / data.matchesPlayed).toFixed(4)) : 0,
+        avgGoals: (data.matchesPlayed && data.matchesPlayed > 0 && data.totalGoals) ? Number((data.totalGoals / data.matchesPlayed).toFixed(4)) : 0,
+        avgAssists: (data.matchesPlayed && data.matchesPlayed > 0 && data.totalAssists) ? Number((data.totalAssists / data.matchesPlayed).toFixed(4)) : 0,
+        avgSaves: (data.matchesPlayed && data.matchesPlayed > 0 && data.totalSaves) ? Number((data.totalSaves / data.matchesPlayed).toFixed(4)) : 0,
+        lastMatchAt: new Date(),
+      },
+      update: {
+        matchesPlayed: { increment: data.matchesPlayed || 0 },
+        wins: { increment: data.wins || 0 },
+        losses: { increment: data.losses || 0 },
+        draws: { increment: data.draws || 0 },
+        totalGoals: { increment: data.totalGoals || 0 },
+        totalAssists: { increment: data.totalAssists || 0 },
+        totalSaves: { increment: data.totalSaves || 0 },
+        totalShots: { increment: data.totalShots || 0 },
+        lastMatchAt: new Date(),
+      },
+    });
+
+    // Recalculate derived stats
+    const matchesPlayed = updated.matchesPlayed;
+    const wins = updated.wins;
+    const winRate = matchesPlayed > 0 ? Number((wins / matchesPlayed).toFixed(4)) : 0;
+    const avgGoals = matchesPlayed > 0 ? Number((updated.totalGoals / matchesPlayed).toFixed(4)) : 0;
+    const avgAssists = matchesPlayed > 0 ? Number((updated.totalAssists / matchesPlayed).toFixed(4)) : 0;
+    const avgSaves = matchesPlayed > 0 ? Number((updated.totalSaves / matchesPlayed).toFixed(4)) : 0;
+
+    // Update derived stats
+    return client.playerLeagueStats.update({
+      where: { playerId_leagueId: { playerId, leagueId } },
+      data: {
+        winRate,
+        avgGoals,
+        avgAssists,
+        avgSaves,
+      },
+    });
+  }
+
   async getLeaderboard(leagueId: string, limit: number = 10) {
     return this.prisma.playerLeagueStats.findMany({
       where: { leagueId },

--- a/src/player-stats/services/player-league-stats.service.ts
+++ b/src/player-stats/services/player-league-stats.service.ts
@@ -17,5 +17,18 @@ export class PlayerLeagueStatsService {
   async updateStats(playerId: string, leagueId: string, stats: any, tx?: Prisma.TransactionClient) {
     return this.repository.upsert(playerId, leagueId, stats, tx);
   }
+
+  async incrementStats(playerId: string, leagueId: string, stats: {
+    matchesPlayed?: number;
+    wins?: number;
+    losses?: number;
+    draws?: number;
+    totalGoals?: number;
+    totalAssists?: number;
+    totalSaves?: number;
+    totalShots?: number;
+  }, tx?: Prisma.TransactionClient) {
+    return this.repository.incrementStats(playerId, leagueId, stats, tx);
+  }
 }
 


### PR DESCRIPTION
Refactor player stats updates to use atomic increments and ensure new players receive a rating record.

The previous implementation for player statistics updates in `MatchService.completeMatch` used a read-modify-write pattern, which was susceptible to race conditions where concurrent match completions for the same player could lead to lost updates. This PR introduces atomic database increments to prevent this. Additionally, the `if (currentRating)` check in `MatchService.completeMatch` prevented new players from having their initial `PlayerLeagueRating` record created, which is now fixed by always calling `updateRating` with `upsert` logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-d5dad132-80f7-4247-85c7-988bd7bbc2f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d5dad132-80f7-4247-85c7-988bd7bbc2f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches player stats updates to atomic increments and always upserts player ratings during match completion to prevent race conditions and missing records.
> 
> - **Match completion (`src/matches/services/match.service.ts`)**:
>   - **Stats**: Replace read-modify-write with `statsService.incrementStats(...)` using atomic increments within the transaction.
>   - **Ratings**: Remove existence check and always call `ratingService.updateRating(...)` (upsert semantics) and set `lastMatchId`.
> - **Player stats module**:
>   - **Repository (`src/player-stats/repositories/player-league-stats.repository.ts`)**: Add `incrementStats(...)` that upserts with atomic increments, then recalculates and updates derived fields (`winRate`, `avgGoals`, `avgAssists`, `avgSaves`).
>   - **Service (`src/player-stats/services/player-league-stats.service.ts`)**: Expose `incrementStats(...)` pass-through.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 553c50b3cfaa8e086b0ebc3116fb0fcc5a934125. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->