### PR TITLE
refactor(app): move global pipes and filters to app module providers

### DIFF
--- a/src/app.module.spec.ts
+++ b/src/app.module.spec.ts
@@ -1,0 +1,107 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ValidationPipe, APP_PIPE } from '@nestjs/core';
+import { ConfigService } from '@nestjs/config';
+import { AppModule } from './app.module';
+
+describe('AppModule', () => {
+  describe('ValidationPipe configuration', () => {
+    it('should create ValidationPipe with whitelist enabled', async () => {
+      const mockConfigService = {
+        get: jest.fn().mockReturnValue('development'),
+      };
+
+      const module = await Test.createTestingModule({
+        imports: [AppModule],
+      })
+        .overrideProvider(ConfigService)
+        .useValue(mockConfigService)
+        .compile();
+
+      const pipe = module.get<ValidationPipe>(APP_PIPE);
+      const pipeOptions = (pipe as any).options;
+
+      expect(pipeOptions.whitelist).toBe(true);
+      await module.close();
+    });
+
+    it('should create ValidationPipe with forbidNonWhitelisted enabled', async () => {
+      const mockConfigService = {
+        get: jest.fn().mockReturnValue('development'),
+      };
+
+      const module = await Test.createTestingModule({
+        imports: [AppModule],
+      })
+        .overrideProvider(ConfigService)
+        .useValue(mockConfigService)
+        .compile();
+
+      const pipe = module.get<ValidationPipe>(APP_PIPE);
+      const pipeOptions = (pipe as any).options;
+
+      expect(pipeOptions.forbidNonWhitelisted).toBe(true);
+      await module.close();
+    });
+
+    it('should create ValidationPipe with transform enabled', async () => {
+      const mockConfigService = {
+        get: jest.fn().mockReturnValue('development'),
+      };
+
+      const module = await Test.createTestingModule({
+        imports: [AppModule],
+      })
+        .overrideProvider(ConfigService)
+        .useValue(mockConfigService)
+        .compile();
+
+      const pipe = module.get<ValidationPipe>(APP_PIPE);
+      const pipeOptions = (pipe as any).options;
+
+      expect(pipeOptions.transform).toBe(true);
+      await module.close();
+    });
+
+    it('should disable error messages in production environment', async () => {
+      const productionConfigService = {
+        get: jest.fn().mockImplementation((key: string) => {
+          if (key === 'app.nodeEnv') return 'production';
+          return undefined;
+        }),
+      };
+
+      const module = await Test.createTestingModule({
+        imports: [AppModule],
+      })
+        .overrideProvider(ConfigService)
+        .useValue(productionConfigService)
+        .compile();
+
+      const pipe = module.get<ValidationPipe>(APP_PIPE);
+      const pipeOptions = (pipe as any).options;
+      expect(pipeOptions.disableErrorMessages).toBe(true);
+
+      await module.close();
+    });
+
+    it('should enable error messages in non-production environment', async () => {
+      const mockConfigService = {
+        get: jest.fn().mockReturnValue('development'),
+      };
+
+      const module = await Test.createTestingModule({
+        imports: [AppModule],
+      })
+        .overrideProvider(ConfigService)
+        .useValue(mockConfigService)
+        .compile();
+
+      const pipe = module.get<ValidationPipe>(APP_PIPE);
+      const pipeOptions = (pipe as any).options;
+      expect(pipeOptions.disableErrorMessages).toBe(false);
+
+      await module.close();
+    });
+  });
+});
+

--- a/src/common/filters/global-exception.filter.spec.ts
+++ b/src/common/filters/global-exception.filter.spec.ts
@@ -1,0 +1,501 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  HttpException,
+  HttpStatus,
+  InternalServerErrorException,
+  BadRequestException,
+  NotFoundException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { GlobalExceptionFilter } from './global-exception.filter';
+import { ArgumentsHost } from '@nestjs/common';
+
+describe('GlobalExceptionFilter', () => {
+  let filter: GlobalExceptionFilter;
+  let configService: ConfigService;
+  let mockArgumentsHost: ArgumentsHost;
+  let mockResponse: any;
+  let mockRequest: any;
+  let loggerErrorSpy: jest.SpyInstance;
+  let loggerWarnSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    // ARRANGE: Setup the testing module
+    const mockConfigService = {
+      get: jest.fn().mockReturnValue('development'),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GlobalExceptionFilter,
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+      ],
+    }).compile();
+
+    filter = module.get<GlobalExceptionFilter>(GlobalExceptionFilter);
+    configService = module.get<ConfigService>(ConfigService);
+
+    // Mock request and response objects
+    mockRequest = {
+      url: '/api/test',
+      method: 'POST',
+      ip: '127.0.0.1',
+      headers: {
+        'user-agent': 'test-agent',
+      },
+    };
+
+    mockResponse = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    // Mock ArgumentsHost
+    mockArgumentsHost = {
+      switchToHttp: jest.fn().mockReturnValue({
+        getResponse: jest.fn().mockReturnValue(mockResponse),
+        getRequest: jest.fn().mockReturnValue(mockRequest),
+      }),
+    } as any;
+
+    // Spy on logger methods
+    loggerErrorSpy = jest.spyOn(filter['logger'], 'error').mockImplementation();
+    loggerWarnSpy = jest.spyOn(filter['logger'], 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(filter).toBeDefined();
+  });
+
+  describe('HttpException handling', () => {
+    it('should handle HttpException with string response and return correct status code', () => {
+      // ARRANGE
+      const exception = new BadRequestException('Invalid input');
+
+      // ACT
+      filter.catch(exception, mockArgumentsHost);
+
+      // ASSERT
+      expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        statusCode: HttpStatus.BAD_REQUEST,
+        timestamp: expect.any(String),
+        path: '/api/test',
+        method: 'POST',
+        message: 'Invalid input',
+      });
+    });
+
+    it('should handle HttpException with object response containing message, code, and details', () => {
+      // ARRANGE
+      const exception = new InternalServerErrorException({
+        message: 'Database connection failed',
+        code: 'DB_CONNECTION_ERROR',
+        details: { host: 'localhost', port: 5432 },
+      });
+
+      // ACT
+      filter.catch(exception, mockArgumentsHost);
+
+      // ASSERT
+      expect(mockResponse.status).toHaveBeenCalledWith(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+        timestamp: expect.any(String),
+        path: '/api/test',
+        method: 'POST',
+        message: 'Database connection failed',
+        code: 'DB_CONNECTION_ERROR',
+        details: { host: 'localhost', port: 5432 },
+      });
+    });
+
+    it('should handle NotFoundException with NOT_FOUND status', () => {
+      // ARRANGE
+      const exception = new NotFoundException('Resource not found');
+
+      // ACT
+      filter.catch(exception, mockArgumentsHost);
+
+      // ASSERT
+      expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.NOT_FOUND);
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: HttpStatus.NOT_FOUND,
+          message: 'Resource not found',
+        }),
+      );
+    });
+
+    it('should include stack trace in development environment', () => {
+      // ARRANGE
+      const exception = new BadRequestException('Test error');
+      const stackTrace = 'Error: Test error\n    at test.js:1:1';
+
+      // Mock stack property
+      Object.defineProperty(exception, 'stack', {
+        value: stackTrace,
+        writable: true,
+      });
+
+      // ACT
+      filter.catch(exception, mockArgumentsHost);
+
+      // ASSERT
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stack: stackTrace,
+        }),
+      );
+    });
+
+    it('should not include stack trace in production environment', async () => {
+      // ARRANGE
+      const productionConfigService = {
+        get: jest.fn().mockReturnValue('production'),
+      };
+
+      const productionModule = await Test.createTestingModule({
+        providers: [
+          GlobalExceptionFilter,
+          {
+            provide: ConfigService,
+            useValue: productionConfigService,
+          },
+        ],
+      }).compile();
+
+      const productionFilter = productionModule.get<GlobalExceptionFilter>(
+        GlobalExceptionFilter,
+      );
+
+      const exception = new BadRequestException('Test error');
+      Object.defineProperty(exception, 'stack', {
+        value: 'Error stack trace',
+        writable: true,
+      });
+
+      const productionHost = {
+        switchToHttp: jest.fn().mockReturnValue({
+          getResponse: jest.fn().mockReturnValue(mockResponse),
+          getRequest: jest.fn().mockReturnValue(mockRequest),
+        }),
+      } as any;
+
+      // ACT
+      productionFilter.catch(exception, productionHost);
+
+      // ASSERT
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stack: undefined,
+        }),
+      );
+
+      await productionModule.close();
+    });
+
+    it('should handle HttpException with null response object', () => {
+      // ARRANGE
+      const exception = new HttpException(null, HttpStatus.BAD_REQUEST);
+
+      // ACT
+      filter.catch(exception, mockArgumentsHost);
+
+      // ASSERT
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Unknown error',
+        }),
+      );
+    });
+  });
+
+  describe('Non-HttpException handling', () => {
+    it('should handle generic Error with INTERNAL_SERVER_ERROR status', () => {
+      // ARRANGE
+      const exception = new Error('Unexpected error occurred');
+      exception.stack = 'Error: Unexpected error occurred\n    at test.js:1:1';
+
+      // ACT
+      filter.catch(exception, mockArgumentsHost);
+
+      // ASSERT
+      expect(mockResponse.status).toHaveBeenCalledWith(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+        timestamp: expect.any(String),
+        path: '/api/test',
+        method: 'POST',
+        message: 'Internal server error',
+        stack: exception.stack,
+      });
+    });
+
+    it('should handle non-Error exceptions with INTERNAL_SERVER_ERROR status', () => {
+      // ARRANGE
+      const exception = 'String error';
+
+      // ACT
+      filter.catch(exception, mockArgumentsHost);
+
+      // ASSERT
+      expect(mockResponse.status).toHaveBeenCalledWith(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+        timestamp: expect.any(String),
+        path: '/api/test',
+        method: 'POST',
+        message: 'Internal server error',
+        stack: undefined,
+      });
+    });
+
+    it('should handle null exceptions with INTERNAL_SERVER_ERROR status', () => {
+      // ARRANGE
+      const exception = null;
+
+      // ACT
+      filter.catch(exception, mockArgumentsHost);
+
+      // ASSERT
+      expect(mockResponse.status).toHaveBeenCalledWith(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Internal server error',
+        }),
+      );
+    });
+
+    it('should handle undefined exceptions with INTERNAL_SERVER_ERROR status', () => {
+      // ARRANGE
+      const exception = undefined;
+
+      // ACT
+      filter.catch(exception, mockArgumentsHost);
+
+      // ASSERT
+      expect(mockResponse.status).toHaveBeenCalledWith(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Internal server error',
+        }),
+      );
+    });
+  });
+
+  describe('Error logging', () => {
+    it('should log errors with status >= 500 using logger.error', () => {
+      // ARRANGE
+      const exception = new InternalServerErrorException('Server error');
+
+      // ACT
+      filter.catch(exception, mockArgumentsHost);
+
+      // ASSERT
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        'POST /api/test - 500 - Server error',
+        expect.objectContaining({
+          exception: expect.any(String),
+          request: expect.objectContaining({
+            method: 'POST',
+            url: '/api/test',
+            ip: '127.0.0.1',
+            userAgent: 'test-agent',
+          }),
+          error: expect.any(Object),
+        }),
+      );
+      expect(loggerWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it('should log errors with status < 500 using logger.warn', () => {
+      // ARRANGE
+      const exception = new BadRequestException('Bad request');
+
+      // ACT
+      filter.catch(exception, mockArgumentsHost);
+
+      // ASSERT
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        'POST /api/test - 400 - Bad request',
+        expect.objectContaining({
+          request: expect.objectContaining({
+            method: 'POST',
+            url: '/api/test',
+          }),
+          error: expect.any(Object),
+        }),
+      );
+      expect(loggerErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it('should log generic Error exceptions with error level', () => {
+      // ARRANGE
+      const exception = new Error('Generic error');
+      exception.stack = 'Error stack';
+
+      // ACT
+      filter.catch(exception, mockArgumentsHost);
+
+      // ASSERT
+      expect(loggerErrorSpy).toHaveBeenCalled();
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        'POST /api/test - 500 - Internal server error',
+        expect.objectContaining({
+          exception: 'Error stack',
+        }),
+      );
+    });
+
+    it('should handle missing user-agent header gracefully', () => {
+      // ARRANGE
+      const requestWithoutUserAgent = {
+        ...mockRequest,
+        headers: {},
+      };
+
+      const hostWithoutUserAgent = {
+        switchToHttp: jest.fn().mockReturnValue({
+          getResponse: jest.fn().mockReturnValue(mockResponse),
+          getRequest: jest.fn().mockReturnValue(requestWithoutUserAgent),
+        }),
+      } as any;
+
+      const exception = new BadRequestException('Test');
+
+      // ACT
+      filter.catch(exception, hostWithoutUserAgent);
+
+      // ASSERT
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          request: expect.objectContaining({
+            userAgent: 'Unknown',
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('Request context extraction', () => {
+    it('should extract request URL, method, IP, and user agent correctly', () => {
+      // ARRANGE
+      const customRequest = {
+        url: '/api/users/123',
+        method: 'GET',
+        ip: '192.168.1.1',
+        headers: {
+          'user-agent': 'Mozilla/5.0',
+        },
+      };
+
+      const customHost = {
+        switchToHttp: jest.fn().mockReturnValue({
+          getResponse: jest.fn().mockReturnValue(mockResponse),
+          getRequest: jest.fn().mockReturnValue(customRequest),
+        }),
+      } as any;
+
+      const exception = new BadRequestException('Test');
+
+      // ACT
+      filter.catch(exception, customHost);
+
+      // ASSERT
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: '/api/users/123',
+          method: 'GET',
+        }),
+      );
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          request: expect.objectContaining({
+            method: 'GET',
+            url: '/api/users/123',
+            ip: '192.168.1.1',
+            userAgent: 'Mozilla/5.0',
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('Environment configuration', () => {
+    it('should use development as default when app.nodeEnv is not set', async () => {
+      // ARRANGE
+      const defaultConfigService = {
+        get: jest.fn().mockReturnValue(undefined),
+      };
+
+      const defaultModule = await Test.createTestingModule({
+        providers: [
+          GlobalExceptionFilter,
+          {
+            provide: ConfigService,
+            useValue: defaultConfigService,
+          },
+        ],
+      }).compile();
+
+      const defaultFilter = defaultModule.get<GlobalExceptionFilter>(
+        GlobalExceptionFilter,
+      );
+
+      const exception = new Error('Test error');
+      exception.stack = 'Error stack';
+
+      // ACT
+      defaultFilter.catch(exception, mockArgumentsHost);
+
+      // ASSERT
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stack: 'Error stack',
+        }),
+      );
+
+      await defaultModule.close();
+    });
+  });
+
+  describe('Timestamp generation', () => {
+    it('should generate ISO timestamp for error response', () => {
+      // ARRANGE
+      const exception = new BadRequestException('Test');
+      const beforeTime = new Date().toISOString();
+
+      // ACT
+      filter.catch(exception, mockArgumentsHost);
+
+      // ASSERT
+      const callArgs = mockResponse.json.mock.calls[0][0];
+      const afterTime = new Date().toISOString();
+
+      expect(callArgs.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+      expect(callArgs.timestamp >= beforeTime).toBe(true);
+      expect(callArgs.timestamp <= afterTime).toBe(true);
+    });
+  });
+});
+

--- a/src/common/filters/prisma-exception.filter.spec.ts
+++ b/src/common/filters/prisma-exception.filter.spec.ts
@@ -1,0 +1,500 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpStatus } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaExceptionFilter } from './prisma-exception.filter';
+import { ArgumentsHost } from '@nestjs/common';
+
+describe('PrismaExceptionFilter', () => {
+  let filter: PrismaExceptionFilter;
+  let mockArgumentsHost: ArgumentsHost;
+  let mockResponse: any;
+  let mockRequest: any;
+  let loggerErrorSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    // ARRANGE: Setup the testing module
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PrismaExceptionFilter],
+    }).compile();
+
+    filter = module.get<PrismaExceptionFilter>(PrismaExceptionFilter);
+
+    // Mock request and response objects
+    mockRequest = {
+      url: '/api/test',
+      method: 'POST',
+    };
+
+    mockResponse = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    // Mock ArgumentsHost
+    mockArgumentsHost = {
+      switchToHttp: jest.fn().mockReturnValue({
+        getResponse: jest.fn().mockReturnValue(mockResponse),
+        getRequest: jest.fn().mockReturnValue(mockRequest),
+      }),
+    } as any;
+
+    // Spy on logger.error
+    loggerErrorSpy = jest.spyOn(filter['logger'], 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(filter).toBeDefined();
+  });
+
+  describe('PrismaClientKnownRequestError handling', () => {
+    it('should handle P2002 (Unique constraint violation) with CONFLICT status', () => {
+      // ARRANGE
+      const exception = new Prisma.PrismaClientKnownRequestError(
+        'Unique constraint failed',
+        {
+          code: 'P2002',
+          clientVersion: '5.0.0',
+          meta: { target: ['email'] },
+        } as any,
+      );
+
+      // ACT
+      filter.catch(exception, mockArgumentsHost);
+
+      // ASSERT
+      expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.CONFLICT);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        statusCode: HttpStatus.CONFLICT,
+        timestamp: expect.any(String),
+        path: '/api/test',
+        method: 'POST',
+        message: 'Unique constraint violation',
+        code: 'UNIQUE_CONSTRAINT_VIOLATION',
+        details: {
+          prismaCode: 'P2002',
+          meta: { target: ['email'] },
+          cause: undefined,
+        },
+      });
+      expect(loggerErrorSpy).toHaveBeenCalled();
+    });
+
+    it('should handle P2025 (Record not found) with NOT_FOUND status', () => {
+      // ARRANGE
+      const exception = new Prisma.PrismaClientKnownRequestError(
+        'Record not found',
+        {
+          code: 'P2025',
+          clientVersion: '5.0.0',
+        } as any,
+      );
+
+      // ACT
+      filter.catch(exception, mockArgumentsHost);
+
+      // ASSERT
+      expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.NOT_FOUND);
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: HttpStatus.NOT_FOUND,
+          message: 'Record not found',
+          code: 'RECORD_NOT_FOUND',
+        }),
+      );
+    });
+
+    it('should handle P2003 (Foreign key constraint violation) with BAD_REQUEST status', () => {
+      // ARRANGE
+      const exception = new Prisma.PrismaClientKnownRequestError(
+        'Foreign key constraint failed',
+        {
+          code: 'P2003',
+          clientVersion: '5.0.0',
+        } as any,
+      );
+
+      // ACT
+      filter.catch(exception, mockArgumentsHost);
+
+      // ASSERT
+      expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: 'FOREIGN_KEY_CONSTRAINT_VIOLATION',
+        }),
+      );
+    });
+
+    it('should handle P2008 (Query timeout) with REQUEST_TIMEOUT status', () => {
+      // ARRANGE
+      const exception = new Prisma.PrismaClientKnownRequestError(
+        'Query timeout',
+        {
+          code: 'P2008',
+          clientVersion: '5.0.0',
+        } as any,
+      );
+
+      // ACT
+      filter.catch(exception, mockArgumentsHost);
+
+      // ASSERT
+      expect(mockResponse.status).toHaveBeenCalledWith(
+        HttpStatus.REQUEST_TIMEOUT,
+      );
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: 'QUERY_TIMEOUT',
+        }),
+      );
+    });
+
+    it('should handle unknown Prisma error codes with INTERNAL_SERVER_ERROR status', () => {
+      // ARRANGE
+      const exception = new Prisma.PrismaClientKnownRequestError(
+        'Unknown error',
+        {
+          code: 'P9999',
+          clientVersion: '5.0.0',
+        } as any,
+      );
+
+      // ACT
+      filter.catch(exception, mockArgumentsHost);
+
+      // ASSERT
+      expect(mockResponse.status).toHaveBeenCalledWith(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Database error',
+          code: 'DATABASE_ERROR',
+        }),
+      );
+    });
+
+    it('should include exception metadata in response details', () => {
+      // ARRANGE
+      const meta = { target: ['username'], field_name: 'username' };
+      const exception = new Prisma.PrismaClientKnownRequestError(
+        'Unique constraint failed',
+        {
+          code: 'P2002',
+          clientVersion: '5.0.0',
+          meta,
+        } as any,
+      );
+
+      // ACT
+      filter.catch(exception, mockArgumentsHost);
+
+      // ASSERT
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          details: expect.objectContaining({
+            meta,
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('PrismaClientValidationError handling', () => {
+    it('should handle validation errors with BAD_REQUEST status', () => {
+      // ARRANGE
+      const exception = new Prisma.PrismaClientValidationError(
+        'Invalid input provided',
+        {
+          cause: 'Field validation failed',
+        } as any,
+      );
+
+      // ACT
+      filter.catch(exception, mockArgumentsHost);
+
+      // ASSERT
+      expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        statusCode: HttpStatus.BAD_REQUEST,
+        timestamp: expect.any(String),
+        path: '/api/test',
+        method: 'POST',
+        message: 'Database validation error',
+        code: 'PRISMA_VALIDATION_ERROR',
+        details: {
+          message: 'Invalid input provided',
+          cause: 'Field validation failed',
+        },
+      });
+      expect(loggerErrorSpy).toHaveBeenCalled();
+    });
+
+    it('should include validation error message and cause in details', () => {
+      // ARRANGE
+      const validationMessage = 'Invalid email format';
+      const validationCause = 'Email must be valid format';
+      const exception = new Prisma.PrismaClientValidationError(
+        validationMessage,
+        {
+          cause: validationCause,
+        } as any,
+      );
+
+      // ACT
+      filter.catch(exception, mockArgumentsHost);
+
+      // ASSERT
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          details: {
+            message: validationMessage,
+            cause: validationCause,
+          },
+        }),
+      );
+    });
+  });
+
+  describe('PrismaClientInitializationError handling', () => {
+    it('should handle initialization errors with SERVICE_UNAVAILABLE status', () => {
+      // ARRANGE
+      const exception = new Prisma.PrismaClientInitializationError(
+        'Connection failed',
+        {
+          errorCode: 'P1001',
+          clientVersion: '5.0.0',
+        } as any,
+      );
+
+      // ACT
+      filter.catch(exception, mockArgumentsHost);
+
+      // ASSERT
+      expect(mockResponse.status).toHaveBeenCalledWith(
+        HttpStatus.SERVICE_UNAVAILABLE,
+      );
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        statusCode: HttpStatus.SERVICE_UNAVAILABLE,
+        timestamp: expect.any(String),
+        path: '/api/test',
+        method: 'POST',
+        message: 'Database connection error',
+        code: 'PRISMA_INITIALIZATION_ERROR',
+        details: {
+          errorCode: 'P1001',
+          clientVersion: '5.0.0',
+          message: 'Connection failed',
+        },
+      });
+      expect(loggerErrorSpy).toHaveBeenCalled();
+    });
+
+    it('should include initialization error details in response', () => {
+      // ARRANGE
+      const exception = new Prisma.PrismaClientInitializationError(
+        'Database connection timeout',
+        {
+          errorCode: 'P1002',
+          clientVersion: '5.1.0',
+        } as any,
+      );
+
+      // ACT
+      filter.catch(exception, mockArgumentsHost);
+
+      // ASSERT
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          details: expect.objectContaining({
+            errorCode: 'P1002',
+            clientVersion: '5.1.0',
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('PrismaClientRustPanicError handling', () => {
+    it('should handle Rust panic errors with INTERNAL_SERVER_ERROR status', () => {
+      // ARRANGE
+      const exception = new Prisma.PrismaClientRustPanicError(
+        'Unexpected panic occurred',
+        {
+          cause: 'Rust panic in query engine',
+        } as any,
+      );
+
+      // ACT
+      filter.catch(exception, mockArgumentsHost);
+
+      // ASSERT
+      expect(mockResponse.status).toHaveBeenCalledWith(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+        timestamp: expect.any(String),
+        path: '/api/test',
+        method: 'POST',
+        message: 'Unexpected database error',
+        code: 'PRISMA_RUST_PANIC_ERROR',
+        details: {
+          message: 'Unexpected panic occurred',
+          cause: 'Rust panic in query engine',
+        },
+      });
+      expect(loggerErrorSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('Fallback error handling', () => {
+    it('should handle unhandled Prisma error types with INTERNAL_SERVER_ERROR status', () => {
+      // ARRANGE
+      const unhandledError = {
+        message: 'Unknown Prisma error',
+      } as any;
+
+      // ACT
+      filter.catch(unhandledError, mockArgumentsHost);
+
+      // ASSERT
+      expect(mockResponse.status).toHaveBeenCalledWith(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Database error',
+          code: 'DATABASE_ERROR',
+          details: {
+            message: 'Unknown Prisma error',
+          },
+        }),
+      );
+    });
+  });
+
+  describe('Error logging', () => {
+    it('should log errors with correct format including method, path, and error code', () => {
+      // ARRANGE
+      const exception = new Prisma.PrismaClientKnownRequestError(
+        'Test error',
+        {
+          code: 'P2002',
+          clientVersion: '5.0.0',
+        } as any,
+      );
+
+      // ACT
+      filter.catch(exception, mockArgumentsHost);
+
+      // ASSERT
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        'POST /api/test - Prisma error: UNIQUE_CONSTRAINT_VIOLATION',
+        expect.objectContaining({
+          error: exception,
+          errorInfo: expect.any(Object),
+          request: expect.objectContaining({
+            method: 'POST',
+            path: '/api/test',
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('Request context extraction', () => {
+    it('should extract request URL, method, and timestamp correctly', () => {
+      // ARRANGE
+      const customRequest = {
+        url: '/api/users/123',
+        method: 'GET',
+      };
+      const customHost = {
+        switchToHttp: jest.fn().mockReturnValue({
+          getResponse: jest.fn().mockReturnValue(mockResponse),
+          getRequest: jest.fn().mockReturnValue(customRequest),
+        }),
+      } as any;
+
+      const exception = new Prisma.PrismaClientKnownRequestError(
+        'Test error',
+        {
+          code: 'P2025',
+          clientVersion: '5.0.0',
+        } as any,
+      );
+
+      // ACT
+      filter.catch(exception, customHost);
+
+      // ASSERT
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: '/api/users/123',
+          method: 'GET',
+          timestamp: expect.any(String),
+        }),
+      );
+    });
+  });
+
+  describe('All Prisma error code mappings', () => {
+    const errorCodeTestCases = [
+      { code: 'P2002', status: HttpStatus.CONFLICT, message: 'Unique constraint violation' },
+      { code: 'P2025', status: HttpStatus.NOT_FOUND, message: 'Record not found' },
+      { code: 'P2003', status: HttpStatus.BAD_REQUEST, message: 'Foreign key constraint violation' },
+      { code: 'P2014', status: HttpStatus.BAD_REQUEST, message: 'Invalid ID provided' },
+      { code: 'P2005', status: HttpStatus.BAD_REQUEST, message: 'Invalid field value' },
+      { code: 'P2006', status: HttpStatus.BAD_REQUEST, message: 'Invalid value provided' },
+      { code: 'P2007', status: HttpStatus.BAD_REQUEST, message: 'Data validation error' },
+      { code: 'P2008', status: HttpStatus.REQUEST_TIMEOUT, message: 'Query execution timeout' },
+      { code: 'P2009', status: HttpStatus.BAD_REQUEST, message: 'Invalid query argument' },
+      { code: 'P2010', status: HttpStatus.INTERNAL_SERVER_ERROR, message: 'Raw query failed' },
+      { code: 'P2011', status: HttpStatus.BAD_REQUEST, message: 'Null constraint violation' },
+      { code: 'P2012', status: HttpStatus.BAD_REQUEST, message: 'Missing required value' },
+      { code: 'P2013', status: HttpStatus.BAD_REQUEST, message: 'Missing required argument' },
+      { code: 'P2015', status: HttpStatus.NOT_FOUND, message: 'Related record not found' },
+      { code: 'P2016', status: HttpStatus.BAD_REQUEST, message: 'Query interpretation error' },
+      { code: 'P2017', status: HttpStatus.BAD_REQUEST, message: 'Records required for operation not found' },
+      { code: 'P2018', status: HttpStatus.BAD_REQUEST, message: 'Required connected records not found' },
+      { code: 'P2019', status: HttpStatus.BAD_REQUEST, message: 'Input error' },
+      { code: 'P2020', status: HttpStatus.BAD_REQUEST, message: 'Value out of range' },
+      { code: 'P2021', status: HttpStatus.NOT_FOUND, message: 'Table does not exist' },
+      { code: 'P2022', status: HttpStatus.BAD_REQUEST, message: 'Column does not exist' },
+      { code: 'P2023', status: HttpStatus.BAD_REQUEST, message: 'Inconsistent column data' },
+      { code: 'P2024', status: HttpStatus.REQUEST_TIMEOUT, message: 'Connection timeout' },
+      { code: 'P2027', status: HttpStatus.BAD_REQUEST, message: 'Multiple errors occurred' },
+    ];
+
+    errorCodeTestCases.forEach(({ code, status, message }) => {
+      it(`should correctly map ${code} to ${status} with message "${message}"`, () => {
+        // ARRANGE
+        const exception = new Prisma.PrismaClientKnownRequestError(
+          'Test error',
+          {
+            code,
+            clientVersion: '5.0.0',
+          } as any,
+        );
+
+        // ACT
+        filter.catch(exception, mockArgumentsHost);
+
+        // ASSERT
+        expect(mockResponse.status).toHaveBeenCalledWith(status);
+        expect(mockResponse.json).toHaveBeenCalledWith(
+          expect.objectContaining({
+            statusCode: status,
+            message,
+          }),
+        );
+      });
+    });
+  });
+});
+

--- a/test/helpers/create-test-app.ts
+++ b/test/helpers/create-test-app.ts
@@ -1,15 +1,7 @@
-import { INestApplication, ValidationPipe } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import { GlobalExceptionFilter } from '../../src/common/filters/global-exception.filter';
-import { PrismaExceptionFilter } from '../../src/common/filters/prisma-exception.filter';
+import { INestApplication } from '@nestjs/common';
 
 /**
- * Bootstrap a test application with production-like configuration
- *
- * Single Responsibility: Configure NestJS app for testing
- * - Applies global pipes (validation)
- * - Applies global filters (error handling)
- * - Initializes the application
+ * Initialize test application with production-like configuration using module-level pipe and filter providers
  *
  * @param app - The NestJS application instance
  * @returns The configured and initialized application
@@ -17,25 +9,6 @@ import { PrismaExceptionFilter } from '../../src/common/filters/prisma-exception
 export async function bootstrapTestApp(
   app: INestApplication,
 ): Promise<INestApplication> {
-  // Get ConfigService from app (must be done after app is created but before init)
-  const configService = app.get(ConfigService);
-
-  // Apply same global pipes as main.ts
-  app.useGlobalPipes(
-    new ValidationPipe({
-      whitelist: true,
-      transform: true,
-      forbidNonWhitelisted: true,
-    }),
-  );
-
-  // Apply same global filters as main.ts
-  // Execution order: Filters are executed in reverse registration order
-  app.useGlobalFilters(
-    new PrismaExceptionFilter(), // Handles Prisma errors first
-    new GlobalExceptionFilter(configService), // Catches all other exceptions
-  );
-
   await app.init();
   return app;
 }


### PR DESCRIPTION
Refactor global ValidationPipe and exception filters from main.ts to app.module.ts using APP_PIPE and APP_FILTER tokens. This improves testability by allowing providers to be overridden in tests and aligns with NestJS best practices for global provider registration.

- Register ValidationPipe via APP_PIPE with factory function for environment-based configuration
- Register PrismaExceptionFilter and GlobalExceptionFilter via APP_FILTER providers
- Remove useGlobalPipes() and useGlobalFilters() calls from main.ts
- Simplify test helper to rely on module-level configuration
- Add comprehensive unit tests for app module and exception filters
- Clean up comments to focus on reasoning rather than syntax

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves global validation and exception handling to `AppModule` providers and adds comprehensive tests; cleans up `main.ts` and simplifies test bootstrap.
> 
> - **AppModule**:
>   - Register global `ValidationPipe` via `APP_PIPE` with env-driven `disableErrorMessages`, `whitelist`, `forbidNonWhitelisted`, and `transform`.
>   - Register `PrismaExceptionFilter` and `GlobalExceptionFilter` via `APP_FILTER` (Prisma first), keep `ThrottlerGuard` and `RequestContextInterceptor`.
> - **Bootstrap** (`src/main.ts`):
>   - Remove `useGlobalPipes()` and `useGlobalFilters()`; retain logger, CORS, Helmet, cookies, Swagger setup, and shutdown hooks.
> - **Tests**:
>   - Add `src/app.module.spec.ts` to verify `ValidationPipe` options and env behavior.
>   - Add comprehensive specs for filters: `src/common/filters/global-exception.filter.spec.ts` and `src/common/filters/prisma-exception.filter.spec.ts`.
> - **Test helper**:
>   - Simplify `test/helpers/create-test-app.ts` to rely on module-level providers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 483be092118eb97421f7302cdd338f314ecc51f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->