### PR TITLE
fix(trackers): add authorization checks to tracker endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ docs/reports/
 
 # Cursor IDE workspace files
 .cursor/worktrees.json
+.cursor/rules/

--- a/src/trackers/repositories/tracker.repository.ts
+++ b/src/trackers/repositories/tracker.repository.ts
@@ -82,7 +82,6 @@ export class TrackerRepository {
       isDeleted: false,
     };
 
-    // Filter by platform
     if (opts.platform) {
       if (Array.isArray(opts.platform)) {
         where.platform = { in: opts.platform };
@@ -91,7 +90,6 @@ export class TrackerRepository {
       }
     }
 
-    // Filter by scraping status
     if (opts.status) {
       if (Array.isArray(opts.status)) {
         where.scrapingStatus = { in: opts.status };
@@ -100,12 +98,9 @@ export class TrackerRepository {
       }
     }
 
-    // Filter by active status
     if (opts.isActive !== undefined) {
       where.isActive = opts.isActive;
     }
-
-    // Sort options
     const orderBy: Prisma.TrackerOrderByWithRelationInput = {};
     if (opts.sortBy) {
       orderBy[opts.sortBy] = opts.sortOrder || 'desc';

--- a/src/trackers/services/tracker-authorization.service.ts
+++ b/src/trackers/services/tracker-authorization.service.ts
@@ -51,7 +51,6 @@ export class TrackerAuthorizationService {
       return;
     }
 
-    // Get all guild memberships for both users
     const currentUserMemberships =
       (await this.guildMembersService.findMembersByUser(
         currentUserId,
@@ -61,7 +60,6 @@ export class TrackerAuthorizationService {
         targetUserId,
       )) as GuildMembershipWithGuild[];
 
-    // Extract guild IDs from memberships
     const currentUserGuildIds = new Set(
       currentUserMemberships.map((m) => m.guildId),
     );
@@ -69,7 +67,6 @@ export class TrackerAuthorizationService {
       targetUserMemberships.map((m) => m.guildId),
     );
 
-    // Find common guilds where both users are members
     const commonGuildIds = Array.from(currentUserGuildIds).filter((guildId) =>
       targetUserGuildIds.has(guildId),
     );
@@ -83,7 +80,6 @@ export class TrackerAuthorizationService {
       );
     }
 
-    // Check if current user is admin in any common guild
     for (const guildId of commonGuildIds) {
       try {
         const settings = await this.guildSettingsService.getSettings(guildId);

--- a/src/trackers/services/tracker-notification.service.ts
+++ b/src/trackers/services/tracker-notification.service.ts
@@ -32,7 +32,6 @@ export class TrackerNotificationService {
     seasonsFailed?: number,
   ): Promise<void> {
     try {
-      // Get user info
       const user = await this.prisma.user.findUnique({
         where: { id: userId },
       });
@@ -42,13 +41,12 @@ export class TrackerNotificationService {
         return;
       }
 
-      // Get tracker info
       const tracker = await this.prisma.tracker.findUnique({
         where: { id: trackerId },
         include: {
           seasons: {
             orderBy: { seasonNumber: 'desc' },
-            take: 1, // Get latest season for info
+            take: 1,
           },
         },
       });
@@ -60,7 +58,6 @@ export class TrackerNotificationService {
         return;
       }
 
-      // Build success embed
       const embed = this.notificationBuilderService.buildScrapingCompleteEmbed(
         tracker,
         user,
@@ -110,7 +107,6 @@ export class TrackerNotificationService {
         return;
       }
 
-      // Get user info for embed
       const user = await this.prisma.user.findUnique({
         where: { id: userId },
       });

--- a/src/trackers/services/tracker-snapshot.service.ts
+++ b/src/trackers/services/tracker-snapshot.service.ts
@@ -40,7 +40,6 @@ export class TrackerSnapshotService {
       guildIds?: string[];
     },
   ) {
-    // Verify tracker exists
     const tracker = await this.trackerRepository.findById(trackerId);
     if (!tracker) {
       throw new NotFoundException('Tracker not found');
@@ -52,14 +51,12 @@ export class TrackerSnapshotService {
       );
     }
 
-    // Create snapshot
     const snapshot = await this.snapshotRepository.create({
       trackerId,
       enteredBy,
       ...data,
     });
 
-    // Add guild visibility if provided
     if (data.guildIds && data.guildIds.length > 0) {
       for (const guildId of data.guildIds) {
         await this.visibilityService.addVisibility(
@@ -89,12 +86,15 @@ export class TrackerSnapshotService {
 
   /**
    * Get all snapshots for a tracker
+   * @param trackerId - Tracker ID
+   * @param skipValidation - If true, skips tracker existence check (use when tracker already validated)
    */
-  async getSnapshotsByTracker(trackerId: string) {
-    // Verify tracker exists
-    const tracker = await this.trackerRepository.findById(trackerId);
-    if (!tracker) {
-      throw new NotFoundException('Tracker not found');
+  async getSnapshotsByTracker(trackerId: string, skipValidation = false) {
+    if (!skipValidation) {
+      const tracker = await this.trackerRepository.findById(trackerId);
+      if (!tracker) {
+        throw new NotFoundException('Tracker not found');
+      }
     }
 
     return this.snapshotRepository.findByTrackerId(trackerId);
@@ -102,15 +102,20 @@ export class TrackerSnapshotService {
 
   /**
    * Get snapshots for a tracker filtered by season
+   * @param trackerId - Tracker ID
+   * @param seasonNumber - Season number to filter by
+   * @param skipValidation - If true, skips tracker existence check (use when tracker already validated)
    */
   async getSnapshotsByTrackerAndSeason(
     trackerId: string,
     seasonNumber: number,
+    skipValidation = false,
   ) {
-    // Verify tracker exists
-    const tracker = await this.trackerRepository.findById(trackerId);
-    if (!tracker) {
-      throw new NotFoundException('Tracker not found');
+    if (!skipValidation) {
+      const tracker = await this.trackerRepository.findById(trackerId);
+      if (!tracker) {
+        throw new NotFoundException('Tracker not found');
+      }
     }
 
     return this.snapshotRepository.findByTrackerIdAndSeason(

--- a/src/trackers/services/tracker.service.ts
+++ b/src/trackers/services/tracker.service.ts
@@ -149,8 +149,25 @@ export class TrackerService {
 
   /**
    * Get scraping status for a tracker
+   * @param trackerId - Tracker ID
+   * @param preFetchedTracker - Optional pre-fetched tracker object with scraping fields. If provided, skips database fetch.
    */
-  async getScrapingStatus(trackerId: string) {
+  async getScrapingStatus(
+    trackerId: string,
+    preFetchedTracker?: Pick<
+      Tracker,
+      'scrapingStatus' | 'scrapingError' | 'lastScrapedAt' | 'scrapingAttempts'
+    >,
+  ) {
+    if (preFetchedTracker) {
+      return {
+        status: preFetchedTracker.scrapingStatus,
+        error: preFetchedTracker.scrapingError,
+        lastScrapedAt: preFetchedTracker.lastScrapedAt,
+        attempts: preFetchedTracker.scrapingAttempts,
+      };
+    }
+
     const tracker = await this.prisma.tracker.findUnique({
       where: { id: trackerId },
       select: {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -59,6 +59,7 @@ export default defineConfig({
     },
     
     // Test timeout (100ms target per test)
+    // TQA Compliance: Unit tests must have timeout < 100ms per TQA Quality Gates
     testTimeout: 100,
     
     // Parallel execution support


### PR DESCRIPTION
Add authorization checks to all tracker endpoints that were missing them. This fixes critical security vulnerabilities where unauthorized users could access, modify, or delete trackers they don't own.

Viewing endpoints (GET) now check for owner OR guild admin access using TrackerAuthorizationService.validateTrackerAccess(). Modifying endpoints (PUT, DELETE, POST snapshots) now enforce owner-only access with direct userId comparison.

All endpoints now return 403 Forbidden when access is denied, and include proper Swagger documentation for the new response code.

Closes #67