### PR TITLE
feat(infrastructure): create infrastructure modules with no-op implementation options

### DIFF
--- a/src/config/configuration.schema.ts
+++ b/src/config/configuration.schema.ts
@@ -37,7 +37,7 @@ export const configurationSchema = Joi.object({
   FRONTEND_URL: Joi.string().required(),
 
   // Rate Limiting
-  THROTTLE_TTL: Joi.number().default(60000), // 1 minute
+  THROTTLE_TTL: Joi.number().default(60000),
   THROTTLE_LIMIT: Joi.number().default(100),
 
   // New Relic Logs API Configuration
@@ -95,4 +95,7 @@ export const configurationSchema = Joi.object({
     .allow('')
     .pattern(/^(\d{17,20})(,\s*\d{17,20})*$/)
     .description('Comma-separated Discord user IDs (snowflakes)'),
+
+  // Gateway Mode Configuration
+  GATEWAY_MODE: Joi.boolean().default(false),
 });

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -15,7 +15,7 @@ export default () => {
       cookieSecure: process.env.NODE_ENV === 'production',
       cookieSameSite:
         (process.env.COOKIE_SAME_SITE as 'lax' | 'strict' | 'none') || 'lax',
-      cookieMaxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
+      cookieMaxAge: 7 * 24 * 60 * 60 * 1000,
     },
     encryption: {
       key: process.env.ENCRYPTION_KEY || '',
@@ -123,6 +123,9 @@ export default () => {
             .map((id) => id.trim())
             .filter(Boolean)
         : [],
+    },
+    gateway: {
+      mode: process.env.GATEWAY_MODE === 'true',
     },
   };
 };

--- a/src/infrastructure/caching/caching.module.ts
+++ b/src/infrastructure/caching/caching.module.ts
@@ -1,0 +1,46 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { CacheModule, CACHE_MANAGER } from '@nestjs/cache-manager';
+import { cacheModuleOptions } from '../../common/config/cache.config';
+import { InAppCachingService } from './services/in-app-caching.service';
+import { NoOpCachingService } from './services/no-op-caching.service';
+import { ICachingService } from './interfaces/caching.interface';
+import type { Cache } from 'cache-manager';
+
+/**
+ * CachingModule - Infrastructure module for caching
+ *
+ * Provides ICachingService with environment-based implementation selection.
+ * Supports both in-app (cache-manager) and no-op (gateway mode) implementations.
+ *
+ * Exports:
+ * - ICachingService token for dependency injection
+ *
+ * Implementation selection:
+ * - In-app: Uses InAppCachingService (cache-manager) when GATEWAY_MODE=false
+ * - No-op: Uses NoOpCachingService when GATEWAY_MODE=true
+ */
+@Module({
+  imports: [
+    ConfigModule,
+    CacheModule.register(cacheModuleOptions), // Required for InAppCachingService
+  ],
+  providers: [
+    {
+      provide: 'ICachingService',
+      useFactory: (
+        configService: ConfigService,
+        cache: Cache,
+      ): ICachingService => {
+        const gatewayMode = configService.get<boolean>('gateway.mode', false);
+        if (gatewayMode) {
+          return new NoOpCachingService();
+        }
+        return new InAppCachingService(cache);
+      },
+      inject: [ConfigService, CACHE_MANAGER],
+    },
+  ],
+  exports: ['ICachingService'],
+})
+export class CachingModule {}

--- a/src/infrastructure/caching/services/no-op-caching.service.ts
+++ b/src/infrastructure/caching/services/no-op-caching.service.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@nestjs/common';
+import { ICachingService } from '../interfaces/caching.interface';
+
+/**
+ * NoOpCachingService - No-op implementation of ICachingService
+ *
+ * Provides a no-op implementation for gateway mode where caching
+ * is handled externally by the API gateway or CDN. All operations
+ * are no-ops that return safe defaults.
+ *
+ * Implementation: No-op (all operations do nothing)
+ */
+@Injectable()
+export class NoOpCachingService implements ICachingService {
+  /**
+   * Get a cached value by key
+   * In gateway mode, caching is handled externally, so always return undefined
+   * @param key - Cache key (unused)
+   * @returns Always undefined (no cached value)
+   */
+  async get<T>(key: string): Promise<T | undefined> {
+    void key;
+    await Promise.resolve();
+    return undefined;
+  }
+
+  /**
+   * Set a value in the cache
+   * In gateway mode, caching is handled externally, so this is a no-op
+   * @param key - Cache key (unused)
+   * @param value - Value to cache (unused)
+   * @param ttl - Optional time-to-live (unused)
+   */
+  async set(key: string, value: unknown, ttl?: number): Promise<void> {
+    void key;
+    void value;
+    void ttl;
+    await Promise.resolve();
+  }
+
+  /**
+   * Delete a cached value by key
+   * In gateway mode, caching is handled externally, so this is a no-op
+   * @param key - Cache key to delete (unused)
+   */
+  async del(key: string): Promise<void> {
+    void key;
+    await Promise.resolve();
+  }
+
+  /**
+   * Reset/clear the entire cache
+   * In gateway mode, caching is handled externally, so this is a no-op
+   */
+  async reset(): Promise<void> {
+    await Promise.resolve();
+  }
+}

--- a/src/infrastructure/configuration/configuration.module.ts
+++ b/src/infrastructure/configuration/configuration.module.ts
@@ -1,0 +1,30 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { InAppConfigurationService } from './services/in-app-configuration.service';
+import { IConfigurationService } from './interfaces/configuration.interface';
+
+/**
+ * ConfigurationModule - Infrastructure module for configuration access
+ *
+ * Provides IConfigurationService interface for dependency injection.
+ * Uses InAppConfigurationService which wraps NestJS ConfigService.
+ *
+ * Exports:
+ * - IConfigurationService token for dependency injection
+ *
+ * Note: No no-op implementation needed - configuration is always required
+ */
+@Module({
+  imports: [ConfigModule],
+  providers: [
+    {
+      provide: 'IConfigurationService',
+      useFactory: (configService: ConfigService): IConfigurationService => {
+        return new InAppConfigurationService(configService);
+      },
+      inject: [ConfigService],
+    },
+  ],
+  exports: ['IConfigurationService'],
+})
+export class ConfigurationModule {}

--- a/src/infrastructure/events/event.module.ts
+++ b/src/infrastructure/events/event.module.ts
@@ -1,0 +1,31 @@
+import { Module } from '@nestjs/common';
+import { OutboxModule } from '../outbox/outbox.module';
+import { OutboxService } from '../outbox/services/outbox.service';
+import { InAppEventService } from './services/in-app-event.service';
+import { IEventService } from './interfaces/event.interface';
+
+/**
+ * EventModule - Infrastructure module for event publishing
+ *
+ * Provides IEventService interface for dependency injection.
+ * Uses InAppEventService which provides in-memory event bus and transactional outbox.
+ *
+ * Exports:
+ * - IEventService token for dependency injection
+ *
+ * Note: No no-op implementation needed - events are always required
+ */
+@Module({
+  imports: [OutboxModule],
+  providers: [
+    {
+      provide: 'IEventService',
+      useFactory: (outboxService: OutboxService): IEventService => {
+        return new InAppEventService(outboxService);
+      },
+      inject: [OutboxService],
+    },
+  ],
+  exports: ['IEventService'],
+})
+export class EventModule {}

--- a/src/infrastructure/infrastructure.module.ts
+++ b/src/infrastructure/infrastructure.module.ts
@@ -4,6 +4,14 @@ import { IdempotencyModule } from './idempotency/idempotency.module';
 import { ActivityLogModule } from './activity-log/activity-log.module';
 import { SettingsModule } from './settings/settings.module';
 import { VisibilityModule } from './visibility/visibility.module';
+import { RateLimitingModule } from './rate-limiting/rate-limiting.module';
+import { CachingModule } from './caching/caching.module';
+import { LoggingModule } from './logging/logging.module';
+import { MetricsModule } from './metrics/metrics.module';
+import { TracingModule } from './tracing/tracing.module';
+import { ConfigurationModule } from './configuration/configuration.module';
+import { TransactionModule } from './transactions/transaction.module';
+import { EventModule } from './events/event.module';
 
 /**
  * InfrastructureModule - Barrel export for all infrastructure modules
@@ -18,6 +26,14 @@ import { VisibilityModule } from './visibility/visibility.module';
     ActivityLogModule,
     SettingsModule,
     VisibilityModule,
+    RateLimitingModule,
+    CachingModule,
+    LoggingModule,
+    MetricsModule,
+    TracingModule,
+    ConfigurationModule,
+    TransactionModule,
+    EventModule,
   ],
   exports: [
     OutboxModule,
@@ -25,6 +41,14 @@ import { VisibilityModule } from './visibility/visibility.module';
     ActivityLogModule,
     SettingsModule,
     VisibilityModule,
+    RateLimitingModule,
+    CachingModule,
+    LoggingModule,
+    MetricsModule,
+    TracingModule,
+    ConfigurationModule,
+    TransactionModule,
+    EventModule,
   ],
 })
 export class InfrastructureModule {}

--- a/src/infrastructure/logging/logging.module.ts
+++ b/src/infrastructure/logging/logging.module.ts
@@ -1,0 +1,32 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { LoggingModule as AppLoggingModule } from '../../logging/logging.module';
+import { NewRelicLoggerService } from '../../logging/newrelic-logger.service';
+import { InAppLoggingService } from './services/in-app-logging.service';
+import { ILoggingService } from './interfaces/logging.interface';
+
+/**
+ * LoggingModule - Infrastructure module for logging
+ *
+ * Provides ILoggingService interface for dependency injection.
+ * Uses InAppLoggingService which wraps NewRelicLoggerService.
+ *
+ * Exports:
+ * - ILoggingService token for dependency injection
+ *
+ * Note: No no-op implementation needed - logging is always required
+ */
+@Module({
+  imports: [ConfigModule, AppLoggingModule],
+  providers: [
+    {
+      provide: 'ILoggingService',
+      useFactory: (newRelicLogger: NewRelicLoggerService): ILoggingService => {
+        return new InAppLoggingService(newRelicLogger);
+      },
+      inject: [NewRelicLoggerService],
+    },
+  ],
+  exports: ['ILoggingService'],
+})
+export class LoggingModule {}

--- a/src/infrastructure/metrics/metrics.module.ts
+++ b/src/infrastructure/metrics/metrics.module.ts
@@ -1,0 +1,29 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { InAppMetricsService } from './services/in-app-metrics.service';
+import { IMetricsService } from './interfaces/metrics.interface';
+
+/**
+ * MetricsModule - Infrastructure module for metrics collection
+ *
+ * Provides IMetricsService interface for dependency injection.
+ * Uses InAppMetricsService which provides in-memory metrics collection.
+ *
+ * Exports:
+ * - IMetricsService token for dependency injection
+ *
+ * Note: No no-op implementation needed - metrics collection is always available
+ */
+@Module({
+  imports: [ConfigModule],
+  providers: [
+    {
+      provide: 'IMetricsService',
+      useFactory: (): IMetricsService => {
+        return new InAppMetricsService();
+      },
+    },
+  ],
+  exports: ['IMetricsService'],
+})
+export class MetricsModule {}

--- a/src/infrastructure/rate-limiting/rate-limiting.module.ts
+++ b/src/infrastructure/rate-limiting/rate-limiting.module.ts
@@ -1,0 +1,46 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { CacheModule, CACHE_MANAGER } from '@nestjs/cache-manager';
+import { cacheModuleOptions } from '../../common/config/cache.config';
+import { InAppRateLimitingService } from './services/in-app-rate-limiting.service';
+import { NoOpRateLimitingService } from './services/no-op-rate-limiting.service';
+import { IRateLimitingService } from './interfaces/rate-limiting.interface';
+import type { Cache } from 'cache-manager';
+
+/**
+ * RateLimitingModule - Infrastructure module for rate limiting
+ *
+ * Provides IRateLimitingService with environment-based implementation selection.
+ * Supports both in-app (cache-manager) and no-op (gateway mode) implementations.
+ *
+ * Exports:
+ * - IRateLimitingService token for dependency injection
+ *
+ * Implementation selection:
+ * - In-app: Uses InAppRateLimitingService (cache-manager) when GATEWAY_MODE=false
+ * - No-op: Uses NoOpRateLimitingService when GATEWAY_MODE=true
+ */
+@Module({
+  imports: [
+    ConfigModule,
+    CacheModule.register(cacheModuleOptions), // Required for InAppRateLimitingService
+  ],
+  providers: [
+    {
+      provide: 'IRateLimitingService',
+      useFactory: (
+        configService: ConfigService,
+        cache: Cache,
+      ): IRateLimitingService => {
+        const gatewayMode = configService.get<boolean>('gateway.mode', false);
+        if (gatewayMode) {
+          return new NoOpRateLimitingService();
+        }
+        return new InAppRateLimitingService(cache);
+      },
+      inject: [ConfigService, CACHE_MANAGER],
+    },
+  ],
+  exports: ['IRateLimitingService'],
+})
+export class RateLimitingModule {}

--- a/src/infrastructure/rate-limiting/services/no-op-rate-limiting.service.ts
+++ b/src/infrastructure/rate-limiting/services/no-op-rate-limiting.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@nestjs/common';
+import { IRateLimitingService } from '../interfaces/rate-limiting.interface';
+
+/**
+ * NoOpRateLimitingService - No-op implementation of IRateLimitingService
+ *
+ * Provides a no-op implementation for gateway mode where rate limiting
+ * is handled externally by the API gateway. All operations are no-ops
+ * that return safe defaults.
+ *
+ * Implementation: No-op (all operations do nothing)
+ */
+@Injectable()
+export class NoOpRateLimitingService implements IRateLimitingService {
+  /**
+   * Check if a key is rate limited
+   * In gateway mode, rate limiting is handled externally, so always return false
+   * @param key - Unique identifier for the rate limit (unused)
+   * @param limit - Maximum number of requests allowed (unused)
+   * @param ttl - Time-to-live in milliseconds (unused)
+   * @returns Always false (never rate limited)
+   */
+  async isRateLimited(
+    key: string,
+    limit: number,
+    ttl: number,
+  ): Promise<boolean> {
+    void key;
+    void limit;
+    void ttl;
+    await Promise.resolve();
+    return false;
+  }
+
+  /**
+   * Increment the counter for a key and return the current count
+   * In gateway mode, rate limiting is handled externally, so always return 0
+   * @param key - Unique identifier for the rate limit (unused)
+   * @param ttl - Time-to-live in milliseconds (unused)
+   * @returns Always 0 (no counting)
+   */
+  async increment(key: string, ttl: number): Promise<number> {
+    void key;
+    void ttl;
+    await Promise.resolve();
+    return 0;
+  }
+}

--- a/src/infrastructure/tracing/tracing.module.ts
+++ b/src/infrastructure/tracing/tracing.module.ts
@@ -1,0 +1,29 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { InAppTracingService } from './services/in-app-tracing.service';
+import { ITracingService } from './interfaces/tracing.interface';
+
+/**
+ * TracingModule - Infrastructure module for distributed tracing
+ *
+ * Provides ITracingService interface for dependency injection.
+ * Uses InAppTracingService which provides in-memory span tracking.
+ *
+ * Exports:
+ * - ITracingService token for dependency injection
+ *
+ * Note: No no-op implementation needed - tracing is always available
+ */
+@Module({
+  imports: [ConfigModule],
+  providers: [
+    {
+      provide: 'ITracingService',
+      useFactory: (): ITracingService => {
+        return new InAppTracingService();
+      },
+    },
+  ],
+  exports: ['ITracingService'],
+})
+export class TracingModule {}

--- a/src/infrastructure/transactions/transaction.module.ts
+++ b/src/infrastructure/transactions/transaction.module.ts
@@ -1,0 +1,31 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../../prisma/prisma.module';
+import { PrismaService } from '../../prisma/prisma.service';
+import { InAppTransactionService } from './services/in-app-transaction.service';
+import { ITransactionService } from './interfaces/transaction.interface';
+
+/**
+ * TransactionModule - Infrastructure module for database transactions
+ *
+ * Provides ITransactionService interface for dependency injection.
+ * Uses InAppTransactionService which wraps Prisma.$transaction().
+ *
+ * Exports:
+ * - ITransactionService token for dependency injection
+ *
+ * Note: No no-op implementation needed - transactions are always required
+ */
+@Module({
+  imports: [PrismaModule],
+  providers: [
+    {
+      provide: 'ITransactionService',
+      useFactory: (prisma: PrismaService): ITransactionService => {
+        return new InAppTransactionService(prisma);
+      },
+      inject: [PrismaService],
+    },
+  ],
+  exports: ['ITransactionService'],
+})
+export class TransactionModule {}

--- a/tests/unit/infrastructure/caching/no-op-caching.service.test.ts
+++ b/tests/unit/infrastructure/caching/no-op-caching.service.test.ts
@@ -1,0 +1,109 @@
+/**
+ * NoOpCachingService Unit Tests
+ *
+ * Tests for no-op caching service implementation.
+ * Focus: Functional core, state verification, fast execution.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { NoOpCachingService } from '@/infrastructure/caching/services/no-op-caching.service';
+
+describe('NoOpCachingService', () => {
+  let service: NoOpCachingService;
+
+  beforeEach(() => {
+    service = new NoOpCachingService();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('get', () => {
+    it('should_return_undefined_when_get_called', async () => {
+      const key = 'test-key';
+
+      const result = await service.get<string>(key);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should_return_undefined_for_any_key', async () => {
+      const key1 = 'key1';
+      const key2 = 'key2';
+
+      const result1 = await service.get<string>(key1);
+      const result2 = await service.get<number>(key2);
+
+      expect(result1).toBeUndefined();
+      expect(result2).toBeUndefined();
+    });
+
+    it('should_return_undefined_for_different_types', async () => {
+      const key = 'test-key';
+
+      const stringResult = await service.get<string>(key);
+      const numberResult = await service.get<number>(key);
+      const objectResult = await service.get<{ data: string }>(key);
+
+      expect(stringResult).toBeUndefined();
+      expect(numberResult).toBeUndefined();
+      expect(objectResult).toBeUndefined();
+    });
+  });
+
+  describe('set', () => {
+    it('should_do_nothing_when_set_called', async () => {
+      const key = 'test-key';
+      const value = { data: 'test' };
+
+      await expect(service.set(key, value)).resolves.toBeUndefined();
+    });
+
+    it('should_do_nothing_when_set_called_with_ttl', async () => {
+      const key = 'test-key';
+      const value = 'test value';
+      const ttl = 5000;
+
+      await expect(service.set(key, value, ttl)).resolves.toBeUndefined();
+    });
+
+    it('should_do_nothing_for_different_value_types', async () => {
+      const key = 'test-key';
+
+      await expect(service.set(key, 'string')).resolves.toBeUndefined();
+      await expect(service.set(key, 42)).resolves.toBeUndefined();
+      await expect(
+        service.set(key, { nested: 'object' }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('del', () => {
+    it('should_do_nothing_when_del_called', async () => {
+      const key = 'test-key';
+
+      await expect(service.del(key)).resolves.toBeUndefined();
+    });
+
+    it('should_do_nothing_for_any_key', async () => {
+      const key1 = 'key1';
+      const key2 = 'non-existent-key';
+
+      await expect(service.del(key1)).resolves.toBeUndefined();
+      await expect(service.del(key2)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('reset', () => {
+    it('should_do_nothing_when_reset_called', async () => {
+      await expect(service.reset()).resolves.toBeUndefined();
+    });
+
+    it('should_do_nothing_when_reset_called_multiple_times', async () => {
+      await expect(service.reset()).resolves.toBeUndefined();
+      await expect(service.reset()).resolves.toBeUndefined();
+      await expect(service.reset()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/tests/unit/infrastructure/rate-limiting/no-op-rate-limiting.service.test.ts
+++ b/tests/unit/infrastructure/rate-limiting/no-op-rate-limiting.service.test.ts
@@ -1,0 +1,120 @@
+/**
+ * NoOpRateLimitingService Unit Tests
+ *
+ * Tests for no-op rate limiting service implementation.
+ * Focus: Functional core, state verification, fast execution.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { NoOpRateLimitingService } from '@/infrastructure/rate-limiting/services/no-op-rate-limiting.service';
+
+describe('NoOpRateLimitingService', () => {
+  let service: NoOpRateLimitingService;
+
+  beforeEach(() => {
+    service = new NoOpRateLimitingService();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('isRateLimited', () => {
+    it('should_return_false_when_isRateLimited_called', async () => {
+      const key = 'test-key';
+      const limit = 10;
+      const ttl = 60000;
+
+      const result = await service.isRateLimited(key, limit, ttl);
+
+      expect(result).toBe(false);
+    });
+
+    it('should_return_false_for_any_key', async () => {
+      const key1 = 'key1';
+      const key2 = 'key2';
+      const limit = 5;
+      const ttl = 30000;
+
+      const result1 = await service.isRateLimited(key1, limit, ttl);
+      const result2 = await service.isRateLimited(key2, limit, ttl);
+
+      expect(result1).toBe(false);
+      expect(result2).toBe(false);
+    });
+
+    it('should_return_false_regardless_of_limit', async () => {
+      const key = 'test-key';
+      const ttl = 60000;
+
+      const result1 = await service.isRateLimited(key, 1, ttl);
+      const result2 = await service.isRateLimited(key, 100, ttl);
+      const result3 = await service.isRateLimited(key, 1000, ttl);
+
+      expect(result1).toBe(false);
+      expect(result2).toBe(false);
+      expect(result3).toBe(false);
+    });
+
+    it('should_return_false_regardless_of_ttl', async () => {
+      const key = 'test-key';
+      const limit = 10;
+
+      const result1 = await service.isRateLimited(key, limit, 1000);
+      const result2 = await service.isRateLimited(key, limit, 60000);
+      const result3 = await service.isRateLimited(key, limit, 3600000);
+
+      expect(result1).toBe(false);
+      expect(result2).toBe(false);
+      expect(result3).toBe(false);
+    });
+  });
+
+  describe('increment', () => {
+    it('should_return_zero_when_increment_called', async () => {
+      const key = 'test-key';
+      const ttl = 60000;
+
+      const result = await service.increment(key, ttl);
+
+      expect(result).toBe(0);
+    });
+
+    it('should_return_zero_for_any_key', async () => {
+      const key1 = 'key1';
+      const key2 = 'key2';
+      const ttl = 30000;
+
+      const result1 = await service.increment(key1, ttl);
+      const result2 = await service.increment(key2, ttl);
+
+      expect(result1).toBe(0);
+      expect(result2).toBe(0);
+    });
+
+    it('should_return_zero_regardless_of_ttl', async () => {
+      const key = 'test-key';
+
+      const result1 = await service.increment(key, 1000);
+      const result2 = await service.increment(key, 60000);
+      const result3 = await service.increment(key, 3600000);
+
+      expect(result1).toBe(0);
+      expect(result2).toBe(0);
+      expect(result3).toBe(0);
+    });
+
+    it('should_return_zero_on_multiple_calls', async () => {
+      const key = 'test-key';
+      const ttl = 60000;
+
+      const result1 = await service.increment(key, ttl);
+      const result2 = await service.increment(key, ttl);
+      const result3 = await service.increment(key, ttl);
+
+      expect(result1).toBe(0);
+      expect(result2).toBe(0);
+      expect(result3).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Description

This PR implements infrastructure modules with support for no-op implementations, enabling gateway mode where infrastructure concerns are handled externally.

## Changes

- ✅ Add CachingModule with in-app and no-op implementations
- ✅ Add RateLimitingModule with in-app and no-op implementations  
- ✅ Add LoggingModule, MetricsModule, TracingModule
- ✅ Add ConfigurationModule, TransactionModule, EventModule
- ✅ Update InfrastructureModule to export all new modules
- ✅ Add configuration schema for infrastructure mode selection
- ✅ Add unit tests for no-op implementations

## Related

Closes #78
Part of #116 (Phase 0: Infrastructure Abstraction Foundation)

## Note

This PR targets the Phase 0 branch (#116) rather than main, as it's part of the infrastructure abstraction foundation work. After merging into the Phase 0 branch, this PR will need to be manually closed.