### PR TITLE
Replace String Injection Tokens with Symbols/Classes

### DIFF
--- a/src/auth/services/league-access-validation.service.ts
+++ b/src/auth/services/league-access-validation.service.ts
@@ -3,6 +3,7 @@ import { LeagueRepository } from '../../leagues/repositories/league.repository';
 import { GuildRepository } from '../../guilds/repositories/guild.repository';
 import { PlayerService } from '../../players/player.service';
 import type { ILeagueMemberAccess } from '../../common/interfaces/league-domain/league-member-access.interface';
+import { ILEAGUE_MEMBER_ACCESS } from '../../common/tokens/injection.tokens';
 import {
   LeagueNotFoundException,
   LeagueAccessDeniedException,
@@ -23,7 +24,7 @@ export class LeagueAccessValidationService {
     private leagueRepository: LeagueRepository,
     private guildRepository: GuildRepository,
     private playerService: PlayerService,
-    @Inject('ILeagueMemberAccess')
+    @Inject(ILEAGUE_MEMBER_ACCESS)
     private leagueMemberAccess: ILeagueMemberAccess,
   ) {}
 

--- a/src/common/tokens/injection.tokens.ts
+++ b/src/common/tokens/injection.tokens.ts
@@ -1,0 +1,30 @@
+/**
+ * Injection Tokens - Symbol-based tokens for dependency injection
+ *
+ * This file exports symbol tokens for all custom providers used throughout the application.
+ * Using symbols instead of string tokens provides:
+ * - Type safety (TypeScript can catch typos)
+ * - Better IDE support (autocomplete, refactoring)
+ * - Self-documenting code
+ * - Prevention of runtime errors from typos
+ *
+ * All tokens follow the pattern: UPPER_SNAKE_CASE matching the interface name
+ */
+
+export const ILEAGUE_SETTINGS_PROVIDER = Symbol('ILeagueSettingsProvider');
+
+export const ILEAGUE_REPOSITORY_ACCESS = Symbol('ILeagueRepositoryAccess');
+
+export const ILEAGUE_MEMBER_ACCESS = Symbol('ILeagueMemberAccess');
+
+export const IGUILD_ACCESS_PROVIDER = Symbol('IGuildAccessProvider');
+
+export const IORGANIZATION_PROVIDER = Symbol('IOrganizationProvider');
+
+export const IORGANIZATION_VALIDATION_PROVIDER = Symbol(
+  'IOrganizationValidationProvider',
+);
+
+export const ITEAM_PROVIDER = Symbol('ITeamProvider');
+
+export const IORGANIZATION_TEAM_PROVIDER = Symbol('IOrganizationTeamProvider');

--- a/src/guilds/adapters/guild-access-adapter.module.ts
+++ b/src/guilds/adapters/guild-access-adapter.module.ts
@@ -4,6 +4,7 @@ import { GuildMembersModule } from '../../guild-members/guild-members.module';
 import { GuildAccessProviderAdapter } from './guild-access-provider.adapter';
 import { GuildSettingsService } from '../guild-settings.service';
 import { GuildMembersService } from '../../guild-members/guild-members.service';
+import { IGUILD_ACCESS_PROVIDER } from '../../common/tokens/injection.tokens';
 
 /**
  * GuildAccessAdapterModule - Provides IGuildAccessProvider adapter
@@ -15,7 +16,7 @@ import { GuildMembersService } from '../../guild-members/guild-members.service';
   imports: [GuildsModule, GuildMembersModule],
   providers: [
     {
-      provide: 'IGuildAccessProvider',
+      provide: IGUILD_ACCESS_PROVIDER,
       useFactory: (
         guildSettingsService: GuildSettingsService,
         guildMembersService: GuildMembersService,
@@ -28,6 +29,6 @@ import { GuildMembersService } from '../../guild-members/guild-members.service';
       inject: [GuildSettingsService, GuildMembersService],
     },
   ],
-  exports: ['IGuildAccessProvider'],
+  exports: [IGUILD_ACCESS_PROVIDER],
 })
 export class GuildAccessAdapterModule {}

--- a/src/guilds/guilds.module.ts
+++ b/src/guilds/guilds.module.ts
@@ -29,6 +29,7 @@ import { GuildAccessValidationService } from './services/guild-access-validation
 import { GuildAuthorizationService } from './services/guild-authorization.service';
 import { GuildAdminGuard } from './guards/guild-admin.guard';
 import { GuildAdminSimpleGuard } from './guards/guild-admin-simple.guard';
+import { IGUILD_ACCESS_PROVIDER } from '../common/tokens/injection.tokens';
 
 @Module({
   imports: [
@@ -64,7 +65,7 @@ import { GuildAdminSimpleGuard } from './guards/guild-admin-simple.guard';
     GuildAdminGuard,
     GuildAdminSimpleGuard,
     {
-      provide: 'IGuildAccessProvider',
+      provide: IGUILD_ACCESS_PROVIDER,
       useFactory: (
         guildSettingsService: GuildSettingsService,
         guildMembersService: GuildMembersService,
@@ -82,7 +83,7 @@ import { GuildAdminSimpleGuard } from './guards/guild-admin-simple.guard';
     GuildSettingsService,
     SettingsDefaultsService,
     GuildRepository,
-    'IGuildAccessProvider',
+    IGUILD_ACCESS_PROVIDER,
     GuildAccessValidationService,
     GuildAuthorizationService,
     GuildAdminGuard,

--- a/src/league-members/league-members.module.ts
+++ b/src/league-members/league-members.module.ts
@@ -17,6 +17,7 @@ import { LeagueJoinValidationService } from './services/league-join-validation.s
 import { LeagueMemberRepository } from './repositories/league-member.repository';
 
 import { LeagueMemberAccessAdapter } from './adapters/league-member-access.adapter';
+import { ILEAGUE_MEMBER_ACCESS } from '../common/tokens/injection.tokens';
 
 @Module({
   imports: [
@@ -35,7 +36,7 @@ import { LeagueMemberAccessAdapter } from './adapters/league-member-access.adapt
     LeagueJoinValidationService,
     LeagueMemberRepository,
     {
-      provide: 'ILeagueMemberAccess',
+      provide: ILEAGUE_MEMBER_ACCESS,
       useClass: LeagueMemberAccessAdapter,
     },
   ],
@@ -43,7 +44,7 @@ import { LeagueMemberAccessAdapter } from './adapters/league-member-access.adapt
     LeagueMemberService,
     LeagueJoinValidationService,
     LeagueMemberRepository,
-    'ILeagueMemberAccess',
+    ILEAGUE_MEMBER_ACCESS,
   ],
 })
 export class LeagueMembersModule {}

--- a/src/league-members/services/league-join-validation.service.ts
+++ b/src/league-members/services/league-join-validation.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, Inject } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import type { ILeagueSettingsProvider } from '../../common/interfaces/league-domain/league-settings-provider.interface';
+import { ILEAGUE_SETTINGS_PROVIDER } from '../../common/tokens/injection.tokens';
 import { LeagueMemberRepository } from '../repositories/league-member.repository';
 import { PlayerService } from '../../players/player.service';
 import { PlayerValidationService } from '../../players/services/player-validation.service';
@@ -21,7 +22,7 @@ export class LeagueJoinValidationService {
 
   constructor(
     private prisma: PrismaService,
-    @Inject('ILeagueSettingsProvider')
+    @Inject(ILEAGUE_SETTINGS_PROVIDER)
     private leagueSettingsProvider: ILeagueSettingsProvider,
     private leagueMemberRepository: LeagueMemberRepository,
     private playerService: PlayerService,

--- a/src/league-members/services/league-member.service.ts
+++ b/src/league-members/services/league-member.service.ts
@@ -15,6 +15,7 @@ import { PlayerService } from '../../players/player.service';
 import { PlayerRepository } from '../../players/repositories/player.repository';
 import { PlayerNotFoundException } from '../../players/exceptions/player.exceptions';
 import type { ILeagueSettingsProvider } from '../../common/interfaces/league-domain/league-settings-provider.interface';
+import { ILEAGUE_SETTINGS_PROVIDER } from '../../common/tokens/injection.tokens';
 import { ActivityLogService } from '../../infrastructure/activity-log/services/activity-log.service';
 import { PlayerLeagueRatingService } from '../../player-ratings/services/player-league-rating.service';
 import { LeagueRepository } from '../../leagues/repositories/league.repository';
@@ -40,7 +41,7 @@ export class LeagueMemberService {
     private joinValidationService: LeagueJoinValidationService,
     private playerService: PlayerService,
     private playerRepository: PlayerRepository,
-    @Inject('ILeagueSettingsProvider')
+    @Inject(ILEAGUE_SETTINGS_PROVIDER)
     private leagueSettingsProvider: ILeagueSettingsProvider,
     private leagueRepository: LeagueRepository,
     private prisma: PrismaService,

--- a/src/leagues/leagues.module.ts
+++ b/src/leagues/leagues.module.ts
@@ -29,6 +29,10 @@ import { LeaguePermissionService } from './services/league-permission.service';
 import { LeagueAccessGuard } from './guards/league-access.guard';
 import { LeagueAdminGuard } from './guards/league-admin.guard';
 import { LeagueAdminOrModeratorGuard } from './guards/league-admin-or-moderator.guard';
+import {
+  ILEAGUE_SETTINGS_PROVIDER,
+  ILEAGUE_REPOSITORY_ACCESS,
+} from '../common/tokens/injection.tokens';
 
 @Module({
   imports: [
@@ -61,14 +65,14 @@ import { LeagueAdminOrModeratorGuard } from './guards/league-admin-or-moderator.
     LeagueAdminGuard,
     LeagueAdminOrModeratorGuard,
     {
-      provide: 'ILeagueSettingsProvider',
+      provide: ILEAGUE_SETTINGS_PROVIDER,
       useFactory: (settingsService: LeagueSettingsService) => {
         return new LeagueSettingsProviderAdapter(settingsService);
       },
       inject: [LeagueSettingsService],
     },
     {
-      provide: 'ILeagueRepositoryAccess',
+      provide: ILEAGUE_REPOSITORY_ACCESS,
       useFactory: (leagueRepository: LeagueRepository) => {
         return new LeagueRepositoryAccessAdapter(leagueRepository);
       },
@@ -80,8 +84,8 @@ import { LeagueAdminOrModeratorGuard } from './guards/league-admin-or-moderator.
     LeagueSettingsService,
     LeagueSettingsDefaultsService,
     LeagueRepository,
-    'ILeagueSettingsProvider',
-    'ILeagueRepositoryAccess',
+    ILEAGUE_SETTINGS_PROVIDER,
+    ILEAGUE_REPOSITORY_ACCESS,
     LeagueAccessValidationService,
     LeaguePermissionService,
     LeagueAccessGuard,

--- a/src/leagues/services/league-access-validation.service.ts
+++ b/src/leagues/services/league-access-validation.service.ts
@@ -3,6 +3,7 @@ import { LeagueRepository } from '../repositories/league.repository';
 import { GuildRepository } from '../../guilds/repositories/guild.repository';
 import { PlayerService } from '../../players/player.service';
 import type { ILeagueMemberAccess } from '../../common/interfaces/league-domain/league-member-access.interface';
+import { ILEAGUE_MEMBER_ACCESS } from '../../common/tokens/injection.tokens';
 import {
   LeagueNotFoundException,
   LeagueAccessDeniedException,
@@ -23,7 +24,7 @@ export class LeagueAccessValidationService {
     private leagueRepository: LeagueRepository,
     private guildRepository: GuildRepository,
     private playerService: PlayerService,
-    @Inject('ILeagueMemberAccess')
+    @Inject(ILEAGUE_MEMBER_ACCESS)
     private leagueMemberAccess: ILeagueMemberAccess,
   ) {}
 

--- a/src/leagues/services/league-permission.service.ts
+++ b/src/leagues/services/league-permission.service.ts
@@ -4,6 +4,7 @@ import { LeagueRepository } from '../repositories/league.repository';
 import { LeagueAccessValidationService } from './league-access-validation.service';
 import { PlayerService } from '../../players/player.service';
 import type { ILeagueMemberAccess } from '../../common/interfaces/league-domain/league-member-access.interface';
+import { ILEAGUE_MEMBER_ACCESS } from '../../common/tokens/injection.tokens';
 import { PermissionCheckService } from '../../permissions/modules/permission-check/permission-check.service';
 import { SettingsService } from '../../infrastructure/settings/services/settings.service';
 import { LeagueNotFoundException } from '../exceptions/league.exceptions';
@@ -22,7 +23,7 @@ export class LeaguePermissionService {
     private leagueRepository: LeagueRepository,
     private leagueAccessValidationService: LeagueAccessValidationService,
     private playerService: PlayerService,
-    @Inject('ILeagueMemberAccess')
+    @Inject(ILEAGUE_MEMBER_ACCESS)
     private leagueMemberAccess: ILeagueMemberAccess,
     private permissionCheckService: PermissionCheckService,
     private settingsService: SettingsService,

--- a/src/organizations/organization.service.ts
+++ b/src/organizations/organization.service.ts
@@ -13,6 +13,11 @@ import { PlayerService } from '@/players/player.service';
 import type { ILeagueRepositoryAccess } from '../common/interfaces/league-domain/league-repository-access.interface';
 import type { ILeagueSettingsProvider } from '../common/interfaces/league-domain/league-settings-provider.interface';
 import type { IOrganizationTeamProvider } from '../common/interfaces/league-domain/organization-team-provider.interface';
+import {
+  ILEAGUE_REPOSITORY_ACCESS,
+  ILEAGUE_SETTINGS_PROVIDER,
+  IORGANIZATION_TEAM_PROVIDER,
+} from '../common/tokens/injection.tokens';
 import { TeamRepository } from '../teams/repositories/team.repository';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateOrganizationDto } from './dto/create-organization.dto';
@@ -37,11 +42,11 @@ export class OrganizationService {
     private organizationMemberService: OrganizationMemberService,
     private validationService: OrganizationValidationService,
     private playerService: PlayerService,
-    @Inject('ILeagueRepositoryAccess')
+    @Inject(ILEAGUE_REPOSITORY_ACCESS)
     private leagueRepositoryAccess: ILeagueRepositoryAccess,
-    @Inject('ILeagueSettingsProvider')
+    @Inject(ILEAGUE_SETTINGS_PROVIDER)
     private leagueSettingsProvider: ILeagueSettingsProvider,
-    @Inject('IOrganizationTeamProvider')
+    @Inject(IORGANIZATION_TEAM_PROVIDER)
     private organizationTeamProvider: IOrganizationTeamProvider,
     private teamRepository: TeamRepository,
     private prisma: PrismaService,

--- a/src/organizations/organizations.module.ts
+++ b/src/organizations/organizations.module.ts
@@ -13,6 +13,10 @@ import { OrganizationValidationProviderAdapter } from './adapters/organization-v
 import { OrganizationProviderAdapter } from './adapters/organization-provider.adapter';
 import { OrganizationAuthorizationService } from './services/organization-authorization.service';
 import { OrganizationGmGuard } from './guards/organization-gm.guard';
+import {
+  IORGANIZATION_PROVIDER,
+  IORGANIZATION_VALIDATION_PROVIDER,
+} from '../common/tokens/injection.tokens';
 
 @Module({
   imports: [
@@ -30,11 +34,11 @@ import { OrganizationGmGuard } from './guards/organization-gm.guard';
     OrganizationAuthorizationService,
     OrganizationGmGuard,
     {
-      provide: 'IOrganizationProvider',
+      provide: IORGANIZATION_PROVIDER,
       useClass: OrganizationProviderAdapter,
     },
     {
-      provide: 'IOrganizationValidationProvider',
+      provide: IORGANIZATION_VALIDATION_PROVIDER,
       useClass: OrganizationValidationProviderAdapter,
     },
   ],
@@ -45,8 +49,8 @@ import { OrganizationGmGuard } from './guards/organization-gm.guard';
     OrganizationValidationService,
     OrganizationAuthorizationService,
     OrganizationGmGuard,
-    'IOrganizationProvider',
-    'IOrganizationValidationProvider',
+    IORGANIZATION_PROVIDER,
+    IORGANIZATION_VALIDATION_PROVIDER,
   ],
 })
 export class OrganizationsModule {}

--- a/src/organizations/services/organization-validation.service.ts
+++ b/src/organizations/services/organization-validation.service.ts
@@ -3,6 +3,10 @@ import { OrganizationRepository } from '../repositories/organization.repository'
 import type { ILeagueRepositoryAccess } from '../../common/interfaces/league-domain/league-repository-access.interface';
 import { PlayerService } from '../../players/player.service';
 import type { ILeagueSettingsProvider } from '../../common/interfaces/league-domain/league-settings-provider.interface';
+import {
+  ILEAGUE_REPOSITORY_ACCESS,
+  ILEAGUE_SETTINGS_PROVIDER,
+} from '../../common/tokens/injection.tokens';
 import { CreateOrganizationDto } from '../dto/create-organization.dto';
 import {
   OrganizationNotFoundException,
@@ -26,10 +30,10 @@ export class OrganizationValidationService {
 
   constructor(
     private organizationRepository: OrganizationRepository,
-    @Inject('ILeagueRepositoryAccess')
+    @Inject(ILEAGUE_REPOSITORY_ACCESS)
     private leagueRepositoryAccess: ILeagueRepositoryAccess,
     private playerService: PlayerService,
-    @Inject('ILeagueSettingsProvider')
+    @Inject(ILEAGUE_SETTINGS_PROVIDER)
     private leagueSettingsProvider: ILeagueSettingsProvider,
   ) {}
 

--- a/src/teams/services/team-validation.service.ts
+++ b/src/teams/services/team-validation.service.ts
@@ -7,6 +7,10 @@ import {
 } from '@nestjs/common';
 import type { ILeagueSettingsProvider } from '../../common/interfaces/league-domain/league-settings-provider.interface';
 import type { IOrganizationValidationProvider } from '../../common/interfaces/league-domain/organization-validation-provider.interface';
+import {
+  ILEAGUE_SETTINGS_PROVIDER,
+  IORGANIZATION_VALIDATION_PROVIDER,
+} from '../../common/tokens/injection.tokens';
 
 /**
  * TeamValidationService - Single Responsibility: Team organization requirement validation
@@ -16,9 +20,9 @@ export class TeamValidationService {
   private readonly logger = new Logger(TeamValidationService.name);
 
   constructor(
-    @Inject('ILeagueSettingsProvider')
+    @Inject(ILEAGUE_SETTINGS_PROVIDER)
     private leagueSettingsProvider: ILeagueSettingsProvider,
-    @Inject('IOrganizationValidationProvider')
+    @Inject(IORGANIZATION_VALIDATION_PROVIDER)
     private organizationValidationProvider: IOrganizationValidationProvider,
   ) {}
 

--- a/src/teams/teams.module.ts
+++ b/src/teams/teams.module.ts
@@ -9,6 +9,10 @@ import { TeamsController } from './teams.controller';
 import { InternalTeamsController } from './internal-teams.controller';
 import { TeamProviderAdapter } from './adapters/team-provider.adapter';
 import { OrganizationTeamProviderAdapter } from './adapters/organization-team-provider.adapter';
+import {
+  ITEAM_PROVIDER,
+  IORGANIZATION_TEAM_PROVIDER,
+} from '../common/tokens/injection.tokens';
 
 @Module({
   imports: [
@@ -22,19 +26,19 @@ import { OrganizationTeamProviderAdapter } from './adapters/organization-team-pr
     TeamRepository,
     TeamValidationService,
     {
-      provide: 'ITeamProvider',
+      provide: ITEAM_PROVIDER,
       useClass: TeamProviderAdapter,
     },
     {
-      provide: 'IOrganizationTeamProvider',
+      provide: IORGANIZATION_TEAM_PROVIDER,
       useClass: OrganizationTeamProviderAdapter,
     },
   ],
   exports: [
     TeamService,
     TeamRepository,
-    'ITeamProvider',
-    'IOrganizationTeamProvider',
+    ITEAM_PROVIDER,
+    IORGANIZATION_TEAM_PROVIDER,
   ],
 })
 export class TeamsModule {}


### PR DESCRIPTION
## Summary
This PR replaces all string-based injection tokens with symbol-based tokens for improved type safety and IDE support.

## Changes
- ✅ Created `src/common/tokens/injection.tokens.ts` with symbol tokens
- ✅ Replaced string tokens with symbols in:
  - `GuildsModule` - `IGUILD_ACCESS_PROVIDER`
  - `LeaguesModule` - `ILEAGUE_SETTINGS_PROVIDER`, `ILEAGUE_REPOSITORY_ACCESS`
  - `LeagueMembersModule` - `ILEAGUE_MEMBER_ACCESS`
- ✅ Verified no remaining string-based injection tokens in codebase
- ✅ All tests passing

## Benefits
- Type safety (TypeScript can catch typos)
- Better IDE support (autocomplete, refactoring)
- Self-documenting code
- Prevention of runtime errors from typos

## Related
Closes #143

## Verification
- [x] All injection tokens use symbols (no string literals)
- [x] Type-safe injection throughout codebase
- [x] No string literals in `provide` or `@Inject`
- [x] All tests pass
- [x] IDE autocomplete works for tokens