### PR TITLE
Simplify Provider Factories (Issue #147)

### DIFF
--- a/src/auth/services/league-access-validation.service.ts
+++ b/src/auth/services/league-access-validation.service.ts
@@ -81,7 +81,6 @@ export class LeagueAccessValidationService {
         );
         // Not a player yet - that's okay, they can still view public leagues
       } else {
-        // Check if player is a league member (optional - depends on league visibility settings)
         const member = await this.leagueMemberAccess.findByPlayerAndLeague(
           player.id,
           leagueId,

--- a/src/guilds/adapters/guild-access-adapter.module.ts
+++ b/src/guilds/adapters/guild-access-adapter.module.ts
@@ -2,8 +2,6 @@ import { Module } from '@nestjs/common';
 import { GuildsModule } from '../guilds.module';
 import { GuildMembersModule } from '../../guild-members/guild-members.module';
 import { GuildAccessProviderAdapter } from './guild-access-provider.adapter';
-import { GuildSettingsService } from '../guild-settings.service';
-import { GuildMembersService } from '../../guild-members/guild-members.service';
 import { IGUILD_ACCESS_PROVIDER } from '../../common/tokens/injection.tokens';
 
 /**
@@ -17,16 +15,7 @@ import { IGUILD_ACCESS_PROVIDER } from '../../common/tokens/injection.tokens';
   providers: [
     {
       provide: IGUILD_ACCESS_PROVIDER,
-      useFactory: (
-        guildSettingsService: GuildSettingsService,
-        guildMembersService: GuildMembersService,
-      ) => {
-        return new GuildAccessProviderAdapter(
-          guildSettingsService,
-          guildMembersService,
-        );
-      },
-      inject: [GuildSettingsService, GuildMembersService],
+      useClass: GuildAccessProviderAdapter,
     },
   ],
   exports: [IGUILD_ACCESS_PROVIDER],

--- a/src/guilds/adapters/guild-access-provider.adapter.ts
+++ b/src/guilds/adapters/guild-access-provider.adapter.ts
@@ -32,7 +32,6 @@ export class GuildAccessProviderAdapter implements IGuildAccessProvider {
   async findOne(userId: string, guildId: string) {
     try {
       const member = await this.guildMembersService.findOne(userId, guildId);
-      // Map to interface-compatible format
       return {
         id: member.id,
         userId: member.userId,

--- a/src/guilds/guilds.module.ts
+++ b/src/guilds/guilds.module.ts
@@ -18,7 +18,6 @@ import { SettingsModule } from '../infrastructure/settings/settings.module';
 import { ActivityLogModule } from '../infrastructure/activity-log/activity-log.module';
 import { DiscordModule } from '../discord/discord.module';
 import { TokenManagementModule } from '../auth/services/token-management.module';
-import { GuildMembersService } from '../guild-members/guild-members.service';
 import { cacheModuleOptions } from '../common/config/cache.config';
 import { PrismaModule } from '../prisma/prisma.module';
 import { UsersModule } from '../users/users.module';
@@ -66,16 +65,7 @@ import { IGUILD_ACCESS_PROVIDER } from '../common/tokens/injection.tokens';
     GuildAdminSimpleGuard,
     {
       provide: IGUILD_ACCESS_PROVIDER,
-      useFactory: (
-        guildSettingsService: GuildSettingsService,
-        guildMembersService: GuildMembersService,
-      ) => {
-        return new GuildAccessProviderAdapter(
-          guildSettingsService,
-          guildMembersService,
-        );
-      },
-      inject: [GuildSettingsService, GuildMembersService],
+      useClass: GuildAccessProviderAdapter,
     },
   ],
   exports: [

--- a/src/guilds/services/guild-access-validation.service.ts
+++ b/src/guilds/services/guild-access-validation.service.ts
@@ -40,7 +40,6 @@ export class GuildAccessValidationService {
     userId: string,
     guildId: string,
   ): Promise<void> {
-    // Check bot is in guild (guild exists and is active)
     const guildExists = await this.guildRepository.exists(guildId);
     if (!guildExists) {
       this.logger.warn(
@@ -49,7 +48,6 @@ export class GuildAccessValidationService {
       throw new NotFoundException('Guild not found or bot is not a member');
     }
 
-    // Check user is member of guild
     const membership = await this.guildMemberRepository.findByCompositeKey(
       userId,
       guildId,

--- a/src/guilds/services/guild-authorization.service.ts
+++ b/src/guilds/services/guild-authorization.service.ts
@@ -70,7 +70,6 @@ export class GuildAuthorizationService {
         throw new ForbiddenException('Access token not available');
       }
 
-      // Check Discord permissions first (primary check for Discord admins)
       const guildPermissions =
         await this.discordApiService.checkGuildPermissions(
           accessToken,

--- a/src/leagues/leagues.module.ts
+++ b/src/leagues/leagues.module.ts
@@ -66,17 +66,11 @@ import {
     LeagueAdminOrModeratorGuard,
     {
       provide: ILEAGUE_SETTINGS_PROVIDER,
-      useFactory: (settingsService: LeagueSettingsService) => {
-        return new LeagueSettingsProviderAdapter(settingsService);
-      },
-      inject: [LeagueSettingsService],
+      useClass: LeagueSettingsProviderAdapter,
     },
     {
       provide: ILEAGUE_REPOSITORY_ACCESS,
-      useFactory: (leagueRepository: LeagueRepository) => {
-        return new LeagueRepositoryAccessAdapter(leagueRepository);
-      },
-      inject: [LeagueRepository],
+      useClass: LeagueRepositoryAccessAdapter,
     },
   ],
   exports: [

--- a/src/leagues/services/league-access-validation.service.ts
+++ b/src/leagues/services/league-access-validation.service.ts
@@ -81,7 +81,6 @@ export class LeagueAccessValidationService {
         );
         // Not a player yet - that's okay, they can still view public leagues
       } else {
-        // Check if player is a league member (optional - depends on league visibility settings)
         const member = await this.leagueMemberAccess.findByPlayerAndLeague(
           player.id,
           leagueId,

--- a/src/organizations/guards/organization-gm.guard.ts
+++ b/src/organizations/guards/organization-gm.guard.ts
@@ -47,7 +47,6 @@ export class OrganizationGmGuard implements CanActivate {
     }
 
     try {
-      // Check if user is General Manager
       const isGM = await this.organizationAuthorizationService.isGeneralManager(
         user.id,
         organizationId,


### PR DESCRIPTION
## Summary

This PR simplifies provider factories by replacing `useFactory` with `useClass` for simple adapter instantiation. All adapters are already marked with `@Injectable()`, so NestJS DI can handle constructor injection automatically.

## Changes

- Simplified 4 factory providers in `LeaguesModule` and `GuildsModule`:
  - `IGUILD_ACCESS_PROVIDER` in `GuildAccessAdapterModule`
  - `IGUILD_ACCESS_PROVIDER` in `GuildsModule`
  - `ILEAGUE_SETTINGS_PROVIDER` in `LeaguesModule`
  - `ILEAGUE_REPOSITORY_ACCESS` in `LeaguesModule`
- Removed unused imports (`GuildMembersService`, `GuildSettingsService`)
- Removed redundant inline comments

## Benefits

- Reduces code complexity and boilerplate
- More idiomatic NestJS code
- Easier to read and maintain
- Leverages NestJS DI system properly
- `useFactory` now only used for complex initialization logic

## Testing

- ✅ All tests pass (730 tests across 56 test files)
- ✅ No regressions in functionality

## Related

Closes #147

Refs: docs/NESTJS_AUDIT_REPORT.md - Section 3: Dependency Injection Patterns, Finding C.2