### PR TITLE
docs(file-structure): add service file location standards

### DIFF
--- a/docs/FILE_STRUCTURE.md
+++ b/docs/FILE_STRUCTURE.md
@@ -39,6 +39,76 @@ Modules with **3 or more controllers** may use a `controllers/` subdirectory for
 - **Simplicity**: Reduces directory nesting and import path complexity
 - **Tooling**: Works seamlessly with NestJS CLI generators
 
+## Service File Locations
+
+### Standard Convention
+
+The **primary domain service** should be located at the **module root** directory, following NestJS CLI conventions. Helper services (validation, orchestration, etc.) may be organized in a `services/` subdirectory when there are multiple services.
+
+**NestJS CLI Behavior:**
+```bash
+nest g service users
+# Generates: src/users/users.service.ts (at module root)
+
+nest g service validation services/users
+# Generates: src/users/services/validation.service.ts (in subdirectory)
+```
+
+### Current Structure
+
+Most modules follow the pattern of primary service at root with helper services in subdirectories:
+
+**Primary Services at Module Root:**
+- `src/leagues/leagues.service.ts` (primary) + `src/leagues/league-settings.service.ts` (also at root)
+- `src/guilds/guilds.service.ts` (primary) + `src/guilds/guild-settings.service.ts` (also at root)
+- `src/trackers/tracker.service.ts` (primary)
+- `src/users/users.service.ts` (primary)
+- `src/players/player.service.ts` (primary)
+- `src/organizations/organization.service.ts` (primary)
+- `src/auth/auth.service.ts` (primary)
+
+**Helper Services in Subdirectories:**
+- `src/leagues/services/` - Contains 5 helper services (validation, permissions, defaults, etc.)
+- `src/guilds/services/` - Contains 6 helper services (validation, authorization, sync, etc.)
+- `src/trackers/services/` - Contains 20+ helper services (scraping, processing, notifications, etc.)
+- `src/users/services/` - Contains helper services (orchestration, etc.)
+- `src/players/services/` - Contains helper services (validation, ownership, etc.)
+- `src/organizations/services/` - Contains helper services (validation, authorization, member management, etc.)
+- `src/auth/services/` - Contains helper services (OAuth, token management, orchestration, etc.)
+
+**Modules with All Services in Subdirectory:**
+Some smaller modules have all services organized in subdirectories:
+- `src/mmr-calculation/services/` - All services including primary `mmr-calculation.service.ts`
+- `src/league-members/services/` - All services including primary `league-member.service.ts`
+- `src/teams/services/` - All services including primary `team.service.ts`
+
+### Exception Policy
+
+Modules with **3 or more services** may organize helper services in a `services/` subdirectory, but the **primary domain service must remain at module root**. The decision to use a subdirectory must be:
+
+1. **Documented** in this file with rationale
+2. **Justified** by clear organizational needs (e.g., many validation/orchestration services)
+3. **Consistent** within the module (primary at root, helpers in subdirectory)
+
+**Primary Service Requirement:**
+- The primary domain service (e.g., `leagues.service.ts`, `guilds.service.ts`) **MUST** be at module root
+- This aligns with NestJS CLI defaults and ensures discoverability
+- Additional related services (e.g., `league-settings.service.ts`) may also be at root if they are core domain services
+
+**Helper Services Organization:**
+- When a module has 3+ services, helper services (validation, orchestration, authorization, etc.) should be organized in a `services/` subdirectory
+- This keeps the module root clean while maintaining organization
+- Examples of helper services: validation services, authorization services, orchestration services, sync services, etc.
+
+### Rationale
+
+- **Consistency**: Aligns with NestJS CLI defaults for primary services, making the codebase predictable
+- **Discoverability**: Primary services are easier to find when located at module root
+- **Organization**: Helper services in subdirectories prevent module root clutter when there are many services
+- **Simplicity**: Primary service at root reduces import path complexity for the most commonly used service
+- **Tooling**: Works seamlessly with NestJS CLI generators for primary services
+- **Scalability**: Subdirectory organization scales well for modules with many helper services
+
 ## Guard File Locations
 
 ### Standard Convention
@@ -113,7 +183,9 @@ All guards follow the **co-location principle**:
 
 ## Related Documentation
 
-- [NestJS CLI Documentation](https://docs.nestjs.com/cli/usages#nest-generate)
+- [NestJS CLI Documentation](https://docs.nestjs.com/cli/usages#nest-generate) - Service and controller generation
+- [NestJS Providers Documentation](https://docs.nestjs.com/providers) - Service implementation patterns
 - [NestJS File Structure Best Practices](https://docs.nestjs.com/fundamentals/module-ref)
 - [NestJS Guards Documentation](https://docs.nestjs.com/guards)
+- `docs/NESTJS_AUDIT_REPORT.md` - Section 1: CLI Structure Alignment, Findings A.2 (Services), A.3 (Controllers)
 


### PR DESCRIPTION
## Description

Documents service file location conventions following NestJS CLI defaults. Primary domain services must be at module root, with helper services organized in `services/` subdirectories when there are 3+ services.

## Changes

- Added "Service File Locations" section to `docs/FILE_STRUCTURE.md`
- Documented standard convention: primary service at module root
- Included examples from leagues, guilds, trackers, users, and other modules
- Defined exception policy (3+ services threshold)
- Updated related documentation references

## Related

Closes #150
Part of Epic #151 (NestJS Architecture Alignment)

## Type

- [x] Documentation only (no code changes)