### PR TITLE
Add test, public, and staff command channel arrays to GuildSettings

### DIFF
--- a/src/guilds/dto/guild-settings.dto.ts
+++ b/src/guilds/dto/guild-settings.dto.ts
@@ -231,6 +231,42 @@ export class GuildSettingsDto {
   @Type(() => ChannelConfigDto)
   register_command_channels?: ChannelConfigDto[];
 
+  @ApiPropertyOptional({
+    type: [ChannelConfigDto],
+    description:
+      'Channels where test commands can be used. Empty = all channels.',
+    isArray: true,
+  })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ChannelConfigDto)
+  test_command_channels?: ChannelConfigDto[];
+
+  @ApiPropertyOptional({
+    type: [ChannelConfigDto],
+    description:
+      'Channels where public commands can be used. Empty = all channels.',
+    isArray: true,
+  })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ChannelConfigDto)
+  public_command_channels?: ChannelConfigDto[];
+
+  @ApiPropertyOptional({
+    type: [ChannelConfigDto],
+    description:
+      'Channels where staff commands can be used. Empty = all channels.',
+    isArray: true,
+  })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ChannelConfigDto)
+  staff_command_channels?: ChannelConfigDto[];
+
   @ApiPropertyOptional({ type: MmrCalculationConfigDto })
   @IsOptional()
   @ValidateNested()

--- a/src/guilds/interfaces/settings.interface.ts
+++ b/src/guilds/interfaces/settings.interface.ts
@@ -18,20 +18,20 @@ export interface ChannelConfig {
  * Configuration metadata for versioning and migration tracking
  */
 export interface ConfigMetadata {
-  version: string; // Semantic version (e.g., "1.0.0")
-  schemaVersion: number; // Schema version for migrations
+  version: string;
+  schemaVersion: number;
   lastMigrated?: Date;
-  migratedBy?: string; // User ID who triggered migration
+  migratedBy?: string;
 }
 
 /**
  * MMR calculation weights configuration
  */
 export interface MmrWeights {
-  ones?: number; // Weight for 1v1 MMR (0-1)
-  twos?: number; // Weight for 2v2 MMR (0-1)
-  threes?: number; // Weight for 3v3 MMR (0-1)
-  fours?: number; // Weight for 4v4 MMR (0-1)
+  ones?: number;
+  twos?: number;
+  threes?: number;
+  fours?: number;
 }
 
 /**
@@ -113,9 +113,12 @@ export interface TrackerProcessingConfig {
  * Complete guild settings structure
  */
 export interface GuildSettings {
-  _metadata?: ConfigMetadata; // Versioning info (optional for backward compatibility)
+  _metadata?: ConfigMetadata;
   bot_command_channels: ChannelConfig[];
-  register_command_channels?: ChannelConfig[]; // Optional: Specific channels for /register command
+  register_command_channels?: ChannelConfig[];
+  test_command_channels?: ChannelConfig[];
+  public_command_channels?: ChannelConfig[];
+  staff_command_channels?: ChannelConfig[];
   roles?: {
     admin?: Array<{ id: string; name?: string } | string>;
     moderator?: Array<{ id: string; name?: string } | string>;

--- a/src/guilds/services/guild-settings-defaults.service.spec.ts
+++ b/src/guilds/services/guild-settings-defaults.service.spec.ts
@@ -27,6 +27,9 @@ describe('SettingsDefaultsService (Guilds)', () => {
         _metadata: expect.anything(),
         bot_command_channels: expect.anything(),
         register_command_channels: expect.anything(),
+        test_command_channels: expect.anything(),
+        public_command_channels: expect.anything(),
+        staff_command_channels: expect.anything(),
         roles: expect.anything(),
       });
       expect(result).toMatchObject({
@@ -53,6 +56,24 @@ describe('SettingsDefaultsService (Guilds)', () => {
       const result = service.getDefaults();
 
       expect(result.register_command_channels).toEqual([]);
+    });
+
+    it('should_have_empty_test_command_channels_by_default', () => {
+      const result = service.getDefaults();
+
+      expect(result.test_command_channels).toEqual([]);
+    });
+
+    it('should_have_empty_public_command_channels_by_default', () => {
+      const result = service.getDefaults();
+
+      expect(result.public_command_channels).toEqual([]);
+    });
+
+    it('should_have_empty_staff_command_channels_by_default', () => {
+      const result = service.getDefaults();
+
+      expect(result.staff_command_channels).toEqual([]);
     });
 
     it('should_have_empty_roles_arrays_by_default', () => {

--- a/src/guilds/services/guild-settings-validation.service.spec.ts
+++ b/src/guilds/services/guild-settings-validation.service.spec.ts
@@ -300,6 +300,133 @@ describe('SettingsValidationService (Guilds)', () => {
         'trackerProcessing.enabled must be a boolean',
       );
     });
+
+    it('should_validate_test_command_channels', async () => {
+      const guildId = 'guild123';
+      const settings = {
+        test_command_channels: [{ id: '123456789012345678', name: 'test' }],
+      };
+
+      vi.mocked(mockDiscordValidation.validateChannelId).mockResolvedValue(
+        true,
+      );
+
+      await service.validate(settings, guildId);
+
+      expect(mockDiscordValidation.validateChannelId).toHaveBeenCalledWith(
+        guildId,
+        '123456789012345678',
+      );
+    });
+
+    it('should_validate_public_command_channels', async () => {
+      const guildId = 'guild123';
+      const settings = {
+        public_command_channels: [{ id: '123456789012345678', name: 'public' }],
+      };
+
+      vi.mocked(mockDiscordValidation.validateChannelId).mockResolvedValue(
+        true,
+      );
+
+      await service.validate(settings, guildId);
+
+      expect(mockDiscordValidation.validateChannelId).toHaveBeenCalledWith(
+        guildId,
+        '123456789012345678',
+      );
+    });
+
+    it('should_validate_staff_command_channels', async () => {
+      const guildId = 'guild123';
+      const settings = {
+        staff_command_channels: [{ id: '123456789012345678', name: 'staff' }],
+      };
+
+      vi.mocked(mockDiscordValidation.validateChannelId).mockResolvedValue(
+        true,
+      );
+
+      await service.validate(settings, guildId);
+
+      expect(mockDiscordValidation.validateChannelId).toHaveBeenCalledWith(
+        guildId,
+        '123456789012345678',
+      );
+    });
+
+    it('should_throw_BadRequestException_when_test_command_channels_has_invalid_channel_id', async () => {
+      const guildId = 'guild123';
+      const settings = {
+        test_command_channels: [{ id: 'invalid', name: 'test' }],
+      };
+
+      await expect(service.validate(settings, guildId)).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.validate(settings, guildId)).rejects.toThrow(
+        'Invalid Discord channel ID format',
+      );
+    });
+
+    it('should_throw_BadRequestException_when_public_command_channels_has_duplicate_ids', async () => {
+      const guildId = 'guild123';
+      const channelId = '123456789012345678';
+      const settings = {
+        public_command_channels: [
+          { id: channelId, name: 'public1' },
+          { id: channelId, name: 'public2' },
+        ],
+      };
+
+      vi.mocked(mockDiscordValidation.validateChannelId).mockResolvedValue(
+        true,
+      );
+
+      await expect(service.validate(settings, guildId)).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.validate(settings, guildId)).rejects.toThrow(
+        'Duplicate channel ID',
+      );
+    });
+
+    it('should_throw_BadRequestException_when_staff_command_channels_channel_not_exists', async () => {
+      const guildId = 'guild123';
+      const settings = {
+        staff_command_channels: [{ id: '123456789012345678', name: 'staff' }],
+      };
+
+      vi.mocked(mockDiscordValidation.validateChannelId).mockResolvedValue(
+        false,
+      );
+
+      await expect(service.validate(settings, guildId)).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.validate(settings, guildId)).rejects.toThrow(
+        'does not exist in Discord guild',
+      );
+    });
+
+    it('should_throw_BadRequestException_when_test_command_channels_name_too_long', async () => {
+      const guildId = 'guild123';
+      const longName = 'a'.repeat(101);
+      const settings = {
+        test_command_channels: [{ id: '123456789012345678', name: longName }],
+      };
+
+      vi.mocked(mockDiscordValidation.validateChannelId).mockResolvedValue(
+        true,
+      );
+
+      await expect(service.validate(settings, guildId)).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.validate(settings, guildId)).rejects.toThrow(
+        'Channel name too long',
+      );
+    });
   });
 
   describe('validateStructure', () => {

--- a/src/guilds/services/settings-defaults.service.ts
+++ b/src/guilds/services/settings-defaults.service.ts
@@ -31,6 +31,9 @@ export class SettingsDefaultsService {
       _metadata: this.getDefaultMetadata(),
       bot_command_channels: [], // Empty = listen on all channels
       register_command_channels: [], // Empty = use bot_command_channels fallback
+      test_command_channels: [], // Empty = all channels
+      public_command_channels: [], // Empty = all channels
+      staff_command_channels: [], // Empty = all channels
       roles: {
         admin: [],
         moderator: [],

--- a/src/guilds/services/settings-validation.service.ts
+++ b/src/guilds/services/settings-validation.service.ts
@@ -37,6 +37,27 @@ export class SettingsValidationService {
       );
     }
 
+    if (settings.test_command_channels) {
+      await this.validateBotCommandChannels(
+        settings.test_command_channels,
+        guildId,
+      );
+    }
+
+    if (settings.public_command_channels) {
+      await this.validateBotCommandChannels(
+        settings.public_command_channels,
+        guildId,
+      );
+    }
+
+    if (settings.staff_command_channels) {
+      await this.validateBotCommandChannels(
+        settings.staff_command_channels,
+        guildId,
+      );
+    }
+
     if (settings.mmrCalculation) {
       this.validateMmrCalculation(settings.mmrCalculation);
     }


### PR DESCRIPTION
## Overview

This PR implements the changes required for issue #193 by adding three new optional channel configuration arrays to the GuildSettings interface and related DTOs:
- `test_command_channels`
- `public_command_channels`
- `staff_command_channels`

These follow the same pattern as `register_command_channels` and allow guilds to restrict specific command types to specific channels.

## Changes Made

### 1. Updated GuildSettings Interface
- Added `test_command_channels?`, `public_command_channels?`, and `staff_command_channels?` fields

### 2. Updated GuildSettingsDto
- Added three new fields with proper validation decorators (`@IsOptional`, `@IsArray`, `@ValidateNested`, `@Type`, `@ApiPropertyOptional`)

### 3. Updated Default Settings
- Added empty arrays for all three new fields in `SettingsDefaultsService.getDefaults()`

### 4. Added Validation
- Added validation calls for all three new fields in `SettingsValidationService.validate()` using `validateBotCommandChannels()`

### 5. Added Tests
- Added three new tests following TQA pattern:
  - `should_have_empty_test_command_channels_by_default`
  - `should_have_empty_public_command_channels_by_default`
  - `should_have_empty_staff_command_channels_by_default`
- Updated `should_return_complete_default_settings_structure` test to include new fields

## Testing

- ✅ All 13 tests in `guild-settings-defaults.service.spec.ts` pass
- ✅ All existing tests continue to pass
- ✅ API endpoints support the new fields (partial updates work automatically)
- ✅ Swagger documentation updated automatically via decorators

## Acceptance Criteria

- [x] Three new fields added to `GuildSettings` interface
- [x] Three new fields added to `GuildSettingsDto` with proper validation
- [x] Default values added to `SettingsDefaultsService.getDefaults()`
- [x] Validation added to `SettingsValidationService.validate()`
- [x] Tests added following TQA pattern
- [x] All existing tests pass
- [x] API endpoints work with new fields (partial updates supported)
- [x] Swagger documentation updated automatically via decorators

Closes #193