### PR TITLE
feat(users): add staff user registration endpoint with tracker support

### DIFF
--- a/docs/API_ENDPOINTS.md
+++ b/docs/API_ENDPOINTS.md
@@ -619,13 +619,22 @@ curl -H "Authorization: Bearer JWT_TOKEN" \
 | `GET` | `/internal/users` | List all users | ✅ API Key |
 | `GET` | `/internal/users/:id` | Get user by ID | ✅ API Key |
 | `POST` | `/internal/users` | Create new user | ✅ API Key |
+| `POST` | `/internal/users/register-by-staff` | Register user with trackers by staff member | ✅ API Key |
 | `PATCH` | `/internal/users/:id` | Update user | ✅ API Key |
 | `DELETE` | `/internal/users/:id` | Delete user | ✅ API Key |
 
 **Example Bot Request:**
 ```bash
+# List all users
 curl -H "Authorization: Bearer BOT_API_KEY" \
   http://localhost:3000/internal/users
+
+# Register user by staff
+curl -H "Authorization: Bearer BOT_API_KEY" \
+  -H "Content-Type: application/json" \
+  -X POST \
+  -d '{"staffUserId":"123456789012345678","guildId":"987654321098765432","userId":"111222333444555666","urls":["https://rocketleague.tracker.network/rocket-league/profile/steam/76561198051701160/overview"]}' \
+  http://localhost:3000/internal/users/register-by-staff
 ```
 
 ### League Management (Bot)

--- a/src/internal/dto/register-by-staff.dto.ts
+++ b/src/internal/dto/register-by-staff.dto.ts
@@ -1,0 +1,106 @@
+import {
+  IsString,
+  IsArray,
+  IsOptional,
+  ValidateNested,
+  ArrayMinSize,
+  ArrayMaxSize,
+  IsUrl,
+  IsNotEmpty,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+class UserDataDto {
+  @ApiProperty({
+    description: 'Discord username',
+    example: 'johndoe',
+  })
+  @IsString()
+  username!: string;
+
+  @ApiPropertyOptional({
+    description: 'Discord global name',
+    example: 'John Doe',
+  })
+  @IsOptional()
+  @IsString()
+  globalName?: string;
+
+  @ApiPropertyOptional({
+    description: 'Discord avatar hash',
+    example: 'a_abc123def456',
+  })
+  @IsOptional()
+  @IsString()
+  avatar?: string;
+}
+
+export class RegisterByStaffDto {
+  @ApiProperty({
+    description: 'Discord user ID of staff member calling the command',
+    example: '123456789012345678',
+  })
+  @IsString()
+  @IsNotEmpty()
+  staffUserId!: string;
+
+  @ApiProperty({
+    description: 'Discord guild ID where command was called',
+    example: '123456789012345678',
+  })
+  @IsString()
+  @IsNotEmpty()
+  guildId!: string;
+
+  @ApiProperty({
+    description: 'Discord user ID of user to register',
+    example: '987654321098765432',
+  })
+  @IsString()
+  @IsNotEmpty()
+  userId!: string;
+
+  @ApiProperty({
+    description: 'Array of tracker URLs (1-4)',
+    example: [
+      'https://rocketleague.tracker.network/rocket-league/profile/steam/76561198051701160/overview',
+      'https://rocketleague.tracker.network/rocket-league/profile/epic/username/overview',
+    ],
+    minItems: 1,
+    maxItems: 4,
+    isArray: true,
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(4)
+  @IsString({ each: true })
+  @IsNotEmpty({ each: true })
+  @IsUrl({}, { each: true })
+  urls!: string[];
+
+  @ApiPropertyOptional({
+    type: UserDataDto,
+    description: 'User data from Discord',
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => UserDataDto)
+  userData?: UserDataDto;
+
+  @ApiPropertyOptional({
+    description: 'Discord channel ID where registration command was called',
+    example: '123456789012345678',
+  })
+  @IsOptional()
+  @IsString()
+  channelId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Discord interaction token for ephemeral follow-up messages',
+    example: 'interaction_token_here',
+  })
+  @IsOptional()
+  @IsString()
+  interactionToken?: string;
+}

--- a/src/users/internal-users.controller.spec.ts
+++ b/src/users/internal-users.controller.spec.ts
@@ -10,15 +10,26 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { Test } from '@nestjs/testing';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { InternalUsersController } from './internal-users.controller';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { User } from '@prisma/client';
+import { RegisterByStaffDto } from '../internal/dto/register-by-staff.dto';
+import { TrackerProcessingService } from '../trackers/services/tracker-processing.service';
+import { PermissionCheckService } from '../permissions/modules/permission-check/permission-check.service';
+import { GuildSettingsService } from '../guilds/guild-settings.service';
+import { DiscordBotService } from '../discord/discord-bot.service';
+import { TrackerScrapingStatus, Game, GamePlatform } from '@prisma/client';
 
 describe('InternalUsersController', () => {
   let controller: InternalUsersController;
   let mockUsersService: UsersService;
+  let mockTrackerProcessingService: TrackerProcessingService;
+  let mockPermissionCheckService: PermissionCheckService;
+  let mockGuildSettingsService: GuildSettingsService;
+  let mockDiscordBotService: DiscordBotService;
 
   const mockUser: User = {
     id: 'user-123',
@@ -45,9 +56,40 @@ describe('InternalUsersController', () => {
       delete: vi.fn(),
     } as unknown as UsersService;
 
+    mockTrackerProcessingService = {
+      registerTrackers: vi.fn(),
+    } as unknown as TrackerProcessingService;
+
+    mockPermissionCheckService = {
+      checkAdminRoles: vi.fn(),
+    } as unknown as PermissionCheckService;
+
+    mockGuildSettingsService = {
+      getSettings: vi.fn(),
+    } as unknown as GuildSettingsService;
+
+    mockDiscordBotService = {
+      getGuildMemberByUserId: vi.fn(),
+    } as unknown as DiscordBotService;
+
     const module = await Test.createTestingModule({
       controllers: [InternalUsersController],
-      providers: [{ provide: UsersService, useValue: mockUsersService }],
+      providers: [
+        { provide: UsersService, useValue: mockUsersService },
+        {
+          provide: TrackerProcessingService,
+          useValue: mockTrackerProcessingService,
+        },
+        {
+          provide: PermissionCheckService,
+          useValue: mockPermissionCheckService,
+        },
+        {
+          provide: GuildSettingsService,
+          useValue: mockGuildSettingsService,
+        },
+        { provide: DiscordBotService, useValue: mockDiscordBotService },
+      ],
     }).compile();
 
     controller = module.get<InternalUsersController>(InternalUsersController);
@@ -183,6 +225,244 @@ describe('InternalUsersController', () => {
 
       expect(result).toEqual(mockUser);
       expect(mockUsersService.delete).toHaveBeenCalledWith('user-123');
+    });
+  });
+
+  describe('registerByStaff', () => {
+    const registerDto: RegisterByStaffDto = {
+      staffUserId: 'staff-123',
+      guildId: 'guild-123',
+      userId: 'user-456',
+      urls: [
+        'https://rocketleague.tracker.network/rocket-league/profile/steam/76561198051701160/overview',
+      ],
+      userData: {
+        username: 'newuser',
+        globalName: 'New User',
+        avatar: 'avatar_hash',
+      },
+      channelId: 'channel-123',
+      interactionToken: 'token-123',
+    };
+
+    const mockGuildSettings = {
+      roles: {
+        admin: [{ id: 'admin-role-1', name: 'Admin' }],
+      },
+    };
+
+    const mockStaffMember = {
+      roles: ['admin-role-1', 'other-role'],
+      user: { id: 'staff-123', username: 'staffuser' },
+    };
+
+    const mockTargetMember = {
+      roles: ['member-role'],
+      user: { id: 'user-456', username: 'newuser' },
+    };
+
+    const mockTrackers = [
+      {
+        id: 'tracker-1',
+        url: 'https://rocketleague.tracker.network/rocket-league/profile/steam/76561198051701160/overview',
+        scrapingStatus: TrackerScrapingStatus.PENDING,
+        game: Game.ROCKET_LEAGUE,
+        platform: GamePlatform.STEAM,
+        userId: 'user-456',
+        username: 'testuser',
+        isActive: true,
+        isDeleted: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+
+    it('should_register_user_with_trackers_when_staff_has_admin_role_and_user_is_guild_member', async () => {
+      vi.spyOn(mockGuildSettingsService, 'getSettings').mockResolvedValue(
+        mockGuildSettings as never,
+      );
+      vi.spyOn(mockDiscordBotService, 'getGuildMemberByUserId')
+        .mockResolvedValueOnce(mockStaffMember)
+        .mockResolvedValueOnce(mockTargetMember);
+      vi.spyOn(mockPermissionCheckService, 'checkAdminRoles').mockResolvedValue(
+        true,
+      );
+      vi.spyOn(
+        mockTrackerProcessingService,
+        'registerTrackers',
+      ).mockResolvedValue(mockTrackers as never);
+      vi.spyOn(mockUsersService, 'findOne').mockResolvedValue(mockUser);
+
+      const result = await controller.registerByStaff(registerDto);
+
+      expect(result).toEqual({
+        user: mockUser,
+        trackers: {
+          count: 1,
+          items: [
+            {
+              id: 'tracker-1',
+              url: 'https://rocketleague.tracker.network/rocket-league/profile/steam/76561198051701160/overview',
+              status: TrackerScrapingStatus.PENDING,
+              game: Game.ROCKET_LEAGUE,
+              platform: GamePlatform.STEAM,
+            },
+          ],
+        },
+      });
+      expect(mockGuildSettingsService.getSettings).toHaveBeenCalledWith(
+        'guild-123',
+      );
+      expect(mockDiscordBotService.getGuildMemberByUserId).toHaveBeenCalledWith(
+        'guild-123',
+        'staff-123',
+      );
+      expect(mockDiscordBotService.getGuildMemberByUserId).toHaveBeenCalledWith(
+        'guild-123',
+        'user-456',
+      );
+      expect(mockPermissionCheckService.checkAdminRoles).toHaveBeenCalledWith(
+        ['admin-role-1', 'other-role'],
+        'guild-123',
+        mockGuildSettings,
+        true,
+      );
+      expect(
+        mockTrackerProcessingService.registerTrackers,
+      ).toHaveBeenCalledWith(
+        'user-456',
+        registerDto.urls,
+        registerDto.userData,
+        'channel-123',
+        'token-123',
+      );
+      expect(mockUsersService.findOne).toHaveBeenCalledWith('user-456');
+    });
+
+    it('should_throw_forbidden_exception_when_staff_member_not_in_guild', async () => {
+      vi.spyOn(mockGuildSettingsService, 'getSettings').mockResolvedValue(
+        mockGuildSettings as never,
+      );
+      vi.spyOn(
+        mockDiscordBotService,
+        'getGuildMemberByUserId',
+      ).mockResolvedValue(null);
+
+      await expect(controller.registerByStaff(registerDto)).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(mockDiscordBotService.getGuildMemberByUserId).toHaveBeenCalledWith(
+        'guild-123',
+        'staff-123',
+      );
+      expect(mockPermissionCheckService.checkAdminRoles).not.toHaveBeenCalled();
+    });
+
+    it('should_throw_forbidden_exception_when_staff_member_does_not_have_admin_role', async () => {
+      vi.spyOn(mockGuildSettingsService, 'getSettings').mockResolvedValue(
+        mockGuildSettings as never,
+      );
+      vi.spyOn(
+        mockDiscordBotService,
+        'getGuildMemberByUserId',
+      ).mockResolvedValue(mockStaffMember);
+      vi.spyOn(mockPermissionCheckService, 'checkAdminRoles').mockResolvedValue(
+        false,
+      );
+
+      await expect(controller.registerByStaff(registerDto)).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(mockPermissionCheckService.checkAdminRoles).toHaveBeenCalled();
+      expect(
+        mockTrackerProcessingService.registerTrackers,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should_throw_forbidden_exception_when_target_user_not_in_guild', async () => {
+      vi.spyOn(mockGuildSettingsService, 'getSettings').mockResolvedValue(
+        mockGuildSettings as never,
+      );
+      vi.spyOn(mockDiscordBotService, 'getGuildMemberByUserId')
+        .mockResolvedValueOnce(mockStaffMember)
+        .mockResolvedValueOnce(null);
+      vi.spyOn(mockPermissionCheckService, 'checkAdminRoles').mockResolvedValue(
+        true,
+      );
+
+      await expect(controller.registerByStaff(registerDto)).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(
+        mockDiscordBotService.getGuildMemberByUserId,
+      ).toHaveBeenCalledTimes(2);
+      expect(
+        mockTrackerProcessingService.registerTrackers,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should_throw_not_found_exception_when_user_not_found_after_registration', async () => {
+      vi.spyOn(mockGuildSettingsService, 'getSettings').mockResolvedValue(
+        mockGuildSettings as never,
+      );
+      vi.spyOn(mockDiscordBotService, 'getGuildMemberByUserId')
+        .mockResolvedValueOnce(mockStaffMember)
+        .mockResolvedValueOnce(mockTargetMember);
+      vi.spyOn(mockPermissionCheckService, 'checkAdminRoles').mockResolvedValue(
+        true,
+      );
+      vi.spyOn(
+        mockTrackerProcessingService,
+        'registerTrackers',
+      ).mockResolvedValue(mockTrackers as never);
+      vi.spyOn(mockUsersService, 'findOne').mockResolvedValue(null as never);
+
+      await expect(controller.registerByStaff(registerDto)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(mockUsersService.findOne).toHaveBeenCalledWith('user-456');
+    });
+
+    it('should_register_multiple_trackers_when_provided', async () => {
+      const multipleTrackersDto: RegisterByStaffDto = {
+        ...registerDto,
+        urls: [
+          'https://rocketleague.tracker.network/rocket-league/profile/steam/76561198051701160/overview',
+          'https://rocketleague.tracker.network/rocket-league/profile/epic/username/overview',
+        ],
+      };
+
+      const multipleMockTrackers = [
+        {
+          ...mockTrackers[0],
+          id: 'tracker-1',
+        },
+        {
+          ...mockTrackers[0],
+          id: 'tracker-2',
+          platform: GamePlatform.EPIC,
+        },
+      ];
+
+      vi.spyOn(mockGuildSettingsService, 'getSettings').mockResolvedValue(
+        mockGuildSettings as never,
+      );
+      vi.spyOn(mockDiscordBotService, 'getGuildMemberByUserId')
+        .mockResolvedValueOnce(mockStaffMember)
+        .mockResolvedValueOnce(mockTargetMember);
+      vi.spyOn(mockPermissionCheckService, 'checkAdminRoles').mockResolvedValue(
+        true,
+      );
+      vi.spyOn(
+        mockTrackerProcessingService,
+        'registerTrackers',
+      ).mockResolvedValue(multipleMockTrackers as never);
+      vi.spyOn(mockUsersService, 'findOne').mockResolvedValue(mockUser);
+
+      const result = await controller.registerByStaff(multipleTrackersDto);
+
+      expect(result.trackers.count).toBe(2);
+      expect(result.trackers.items).toHaveLength(2);
     });
   });
 });

--- a/src/users/internal-users.controller.ts
+++ b/src/users/internal-users.controller.ts
@@ -7,6 +7,9 @@ import {
   Param,
   Body,
   UseGuards,
+  ForbiddenException,
+  NotFoundException,
+  Logger,
 } from '@nestjs/common';
 import { SkipThrottle } from '@nestjs/throttler';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
@@ -16,6 +19,11 @@ import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { ParseCUIDPipe } from '../common/pipes';
+import { RegisterByStaffDto } from '../internal/dto/register-by-staff.dto';
+import { TrackerProcessingService } from '../trackers/services/tracker-processing.service';
+import { PermissionCheckService } from '../permissions/modules/permission-check/permission-check.service';
+import { GuildSettingsService } from '../guilds/guild-settings.service';
+import { DiscordBotService } from '../discord/discord-bot.service';
 
 /**
  * InternalUsersController - Bot-only endpoints for full user management
@@ -27,7 +35,15 @@ import { ParseCUIDPipe } from '../common/pipes';
 @SkipThrottle()
 @BotOnly()
 export class InternalUsersController {
-  constructor(private usersService: UsersService) {}
+  private readonly logger = new Logger(InternalUsersController.name);
+
+  constructor(
+    private usersService: UsersService,
+    private trackerProcessingService: TrackerProcessingService,
+    private permissionCheckService: PermissionCheckService,
+    private guildSettingsService: GuildSettingsService,
+    private discordBotService: DiscordBotService,
+  ) {}
 
   @Get()
   @ApiOperation({ summary: 'Get all users (bot only)' })
@@ -69,5 +85,99 @@ export class InternalUsersController {
   @ApiResponse({ status: 404, description: 'User not found' })
   delete(@Param('id', ParseCUIDPipe) id: string) {
     return this.usersService.delete(id);
+  }
+
+  @Post('register-by-staff')
+  @ApiOperation({
+    summary: 'Register user with trackers by staff member (bot only)',
+    description:
+      'Allows staff members to register a user into the system with up to 4 trackers. Validates staff permissions and guild membership.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'User registered successfully with trackers',
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden - staff role or guild membership validation failed',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid request data or user already has trackers',
+  })
+  @ApiResponse({ status: 404, description: 'Guild not found' })
+  async registerByStaff(@Body() dto: RegisterByStaffDto) {
+    // 1. Validate staff member has admin role in guild
+    const guildSettings = await this.guildSettingsService.getSettings(
+      dto.guildId,
+    );
+
+    const staffMember = await this.discordBotService.getGuildMemberByUserId(
+      dto.guildId,
+      dto.staffUserId,
+    );
+
+    if (!staffMember) {
+      throw new ForbiddenException(
+        `Staff member ${dto.staffUserId} is not a member of guild ${dto.guildId}`,
+      );
+    }
+
+    const hasAdminRole = await this.permissionCheckService.checkAdminRoles(
+      staffMember.roles,
+      dto.guildId,
+      guildSettings,
+      true, // validateWithDiscord
+    );
+
+    if (!hasAdminRole) {
+      throw new ForbiddenException(
+        `Staff member ${dto.staffUserId} does not have admin role in guild ${dto.guildId}`,
+      );
+    }
+
+    // 2. Validate target user is member of guild
+    const targetMember = await this.discordBotService.getGuildMemberByUserId(
+      dto.guildId,
+      dto.userId,
+    );
+
+    if (!targetMember) {
+      throw new ForbiddenException(
+        `User ${dto.userId} is not a member of guild ${dto.guildId}`,
+      );
+    }
+
+    // 3. Register trackers (this also ensures user exists)
+    const trackers = await this.trackerProcessingService.registerTrackers(
+      dto.userId,
+      dto.urls,
+      dto.userData,
+      dto.channelId,
+      dto.interactionToken,
+    );
+
+    // 4. Get user object
+    const user = await this.usersService.findOne(dto.userId);
+    if (!user) {
+      throw new NotFoundException(
+        `User ${dto.userId} not found after registration`,
+      );
+    }
+
+    // 5. Format response with user and tracker status information
+    return {
+      user,
+      trackers: {
+        count: trackers.length,
+        items: trackers.map((tracker) => ({
+          id: tracker.id,
+          url: tracker.url,
+          status: tracker.scrapingStatus,
+          game: tracker.game,
+          platform: tracker.platform,
+        })),
+      },
+    };
   }
 }

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -7,9 +7,20 @@ import { UserRepository } from './repositories/user.repository';
 import { UserOrchestratorService } from './services/user-orchestrator.service';
 import { EncryptionModule } from '../common/encryption.module';
 import { PrismaModule } from '../prisma/prisma.module';
+import { TrackersModule } from '../trackers/trackers.module';
+import { GuildsModule } from '../guilds/guilds.module';
+import { DiscordModule } from '../discord/discord.module';
+import { PermissionCheckModule } from '../permissions/modules/permission-check/permission-check.module';
 
 @Module({
-  imports: [EncryptionModule, PrismaModule],
+  imports: [
+    EncryptionModule,
+    PrismaModule,
+    TrackersModule,
+    GuildsModule,
+    DiscordModule,
+    PermissionCheckModule,
+  ],
   controllers: [InternalUsersController, UsersController],
   providers: [
     UsersService,


### PR DESCRIPTION
Implements POST /internal/users/register-by-staff endpoint that allows staff members to register users with trackers. Validates staff admin permissions and guild membership before registration. Adds DiscordBotService.getGuildMemberByUserId() method for membership validation. Includes comprehensive unit tests and API documentation updates.